### PR TITLE
add an option to interpolate health and armor for Doom and Chex

### DIFF
--- a/cvarinfo
+++ b/cvarinfo
@@ -5,10 +5,12 @@ user int   fullhud_opaque        = 0;
 user bool  fullhud_boomcolors    = false;
 user bool  fullhud_automaphide   = false;
 
-user int fullhud_stats_type      = 0; 
-user int fullhud_stats_font	 = 0;
-user int fullhud_stats_comp	 = 0;
+user int fullhud_stats_type      = 0;
+user int fullhud_stats_font      = 0;
+user int fullhud_stats_comp      = 0;
 user int fullhud_stats_kills     = 0;
 user int fullhud_stats_secrets   = 0;
 user int fullhud_stats_items     = 0;
-user int fullhud_stats_time      = 0; 
+user int fullhud_stats_time      = 0;
+
+user bool fullhud_interpolate_health_armor = false;

--- a/filter/game-doomchex/menudef
+++ b/filter/game-doomchex/menudef
@@ -25,6 +25,8 @@ OptionMenu "FullscreenStatusbarOptions"
 	Option "Show arms on split bar", "fullhud_splitarms", "OnOff", "fullhud_split"	
 	Option "Inventory items can replace mugshot", "fullhud_invovermug", "OnOff"
 	Option "Hide status bar on automap", "fullhud_automaphide", "OnOff"
+	Option "Interpolate health and armor", "fullhud_interpolate_health_armor", "OnOff"
+
    	StaticText ""
    	StaticText  "Level Stats", "gold"
 	Option "Stats display", "fullhud_stats_type", "LevelStats"

--- a/filter/game-doomchex/zscript/statusbars/main.zs
+++ b/filter/game-doomchex/zscript/statusbars/main.zs
@@ -18,6 +18,8 @@ Class SpecialDoomStatusBar : DoomStatusBar
 	transient CVAR statSecrets;
 	transient CVAR statItems;
 	transient CVAR statTime;
+
+	transient CVAR interpolateHealthArmor;
 	
 	InventoryBarState diparms_sbar;
 	HUDFont mIndexFontF;
@@ -37,6 +39,9 @@ Class SpecialDoomStatusBar : DoomStatusBar
 
 	// Offset for Split Arms
 	double ARMS_OFFSET;
+
+	LinearValueInterpolator healthInterpolator;
+	LinearValueInterpolator armorInterpolator;
 
 	enum OpaqueValues
 	{
@@ -67,6 +72,8 @@ Class SpecialDoomStatusBar : DoomStatusBar
 		statSecrets    = CVar.FindCVar("fullhud_stats_secrets");
 		statItems      = CVar.FindCVar("fullhud_stats_items");
 		statTime       = CVar.FindCVar("fullhud_stats_time");
+
+		interpolateHealthArmor = CVar.FindCVar("fullhud_interpolate_health_armor");
 
 		diparms_sbar = InventoryBarState.CreateNoBox(mIndexFont, boxsize:(31, 31), arrowoffs:(0,-10));
 		
@@ -99,6 +106,9 @@ Class SpecialDoomStatusBar : DoomStatusBar
 		//console.printf("\nSTBAR Hash is: 0x%08X",STBAR_HASH);
 
 		setSTBARNames();
+
+		healthInterpolator = LinearValueInterpolator.Create(0, 10);
+		armorInterpolator  = LinearValueInterpolator.Create(0, 10);
 	}
 
 	override void NewGame()
@@ -111,6 +121,9 @@ Class SpecialDoomStatusBar : DoomStatusBar
 	override void Tick()
 	{
 		Super.Tick();
+
+		healthInterpolator.Update(CPlayer.health);
+		armorInterpolator.Update(GetArmorAmount());
 
 		statTick();
 	}
@@ -167,5 +180,17 @@ Class SpecialDoomStatusBar : DoomStatusBar
 	string concat(string s1, string s2)
 	{
 		return string.format("%s%s",s1,s2);
+	}
+
+	string getHealthString()
+	{
+		int healthValue = interpolateHealthArmor.GetBool() ? healthInterpolator.GetValue() : CPlayer.health;
+		return FormatNumber(healthValue, 3);
+	}
+
+	string getArmorString()
+	{
+		int armorValue = interpolateHealthArmor.GetBool() ? armorInterpolator.GetValue() : GetArmorAmount();
+		return FormatNumber(armorValue, 3);
 	}
 }

--- a/filter/game-doomchex/zscript/statusbars/split.zs
+++ b/filter/game-doomchex/zscript/statusbars/split.zs
@@ -30,11 +30,11 @@ extend Class SpecialDoomStatusBar
 		
 		// Draw Health
 		int healthColor = GetHealthColor();
-		DrawString(mHUDFont, FormatNumber(CPlayer.health, 3), (90+isChex(1), -29), DI_TEXT_ALIGN_RIGHT|DI_NOSHADOW|DI_SCREEN_LEFT_BOTTOM, translation: healthColor, alpha:alphaFloatNum);
+		DrawString(mHUDFont, getHealthString(), (90+isChex(1), -29), DI_TEXT_ALIGN_RIGHT|DI_NOSHADOW|DI_SCREEN_LEFT_BOTTOM, translation: healthColor, alpha:alphaFloatNum);
 		
 		// Draw Armor
 		int armorColor = GetArmorColor();
-		DrawString(mHUDFont, FormatNumber(GetArmorAmount(), 3), (-99+isChex(2), -29), DI_TEXT_ALIGN_RIGHT|DI_NOSHADOW|DI_SCREEN_RIGHT_BOTTOM, translation:armorColor, alpha:alphaFloatNum);
+		DrawString(mHUDFont, getArmorString(), (-99+isChex(2), -29), DI_TEXT_ALIGN_RIGHT|DI_NOSHADOW|DI_SCREEN_RIGHT_BOTTOM, translation:armorColor, alpha:alphaFloatNum);
 
 		// Draw Keys
 		bool locks[6];

--- a/filter/game-doomchex/zscript/statusbars/unsplit.zs
+++ b/filter/game-doomchex/zscript/statusbars/unsplit.zs
@@ -41,11 +41,11 @@ extend Class SpecialDoomStatusBar
 		
 		// Draw Health
 		int healthColor = GetHealthColor();
-		DrawString(mHUDFont, FormatNumber(CPlayer.health, 3), (-70+isChex(1), -29), DI_TEXT_ALIGN_RIGHT|DI_NOSHADOW|DI_SCREEN_CENTER_BOTTOM, translation: healthColor, alpha:alphaFloatNum);
+		DrawString(mHUDFont, getHealthString(), (-70+isChex(1), -29), DI_TEXT_ALIGN_RIGHT|DI_NOSHADOW|DI_SCREEN_CENTER_BOTTOM, translation: healthColor, alpha:alphaFloatNum);
 		
 		// Draw Armor
 		int armorColor = GetArmorColor();
-		DrawString(mHUDFont, FormatNumber(GetArmorAmount(), 3), (61+isChex(2), -29), DI_TEXT_ALIGN_RIGHT|DI_NOSHADOW|DI_SCREEN_CENTER_BOTTOM, translation:armorColor, alpha:alphaFloatNum);
+		DrawString(mHUDFont, getArmorString(), (61+isChex(2), -29), DI_TEXT_ALIGN_RIGHT|DI_NOSHADOW|DI_SCREEN_CENTER_BOTTOM, translation:armorColor, alpha:alphaFloatNum);
 
 		// Draw Keys
 		bool locks[6];


### PR DESCRIPTION
Not sure if you want this feature, but here is an option to interpolate (animate) health and armor for Doom and Chex.