### PR TITLE
Add support for stats adjacent to status bar

### DIFF
--- a/cvarinfo
+++ b/cvarinfo
@@ -6,12 +6,13 @@ user bool  fullhud_boomcolors     = false;
 user bool  fullhud_splitarms      = false;
 user bool  fullhud_automaphide    = false;
 
-user int   fullhud_stats_type     = 0; 
+user int   fullhud_stats_type     = 0;
 user int   fullhud_stats_font     = 0;
 user int   fullhud_stats_comp     = 0;
 user int   fullhud_stats_kills    = 0;
 user int   fullhud_stats_secrets  = 0;
 user int   fullhud_stats_items    = 0;
-user int   fullhud_stats_time     = 0; 
+user int   fullhud_stats_time     = 0;
 user int   fullhud_stats_powerups = 0;
 user bool  fullhud_stats_short    = false;
+user bool  fullhud_stats_cozy     = false;

--- a/cvarinfo
+++ b/cvarinfo
@@ -6,13 +6,12 @@ user bool  fullhud_boomcolors     = false;
 user bool  fullhud_splitarms      = false;
 user bool  fullhud_automaphide    = false;
 
-user int   fullhud_stats_type     = 0;
+user int   fullhud_stats_type     = 0; 
 user int   fullhud_stats_font     = 0;
 user int   fullhud_stats_comp     = 0;
 user int   fullhud_stats_kills    = 0;
 user int   fullhud_stats_secrets  = 0;
 user int   fullhud_stats_items    = 0;
-user int   fullhud_stats_time     = 0;
+user int   fullhud_stats_time     = 0; 
 user int   fullhud_stats_powerups = 0;
 user bool  fullhud_stats_short    = false;
-user bool  fullhud_stats_cozy     = false;

--- a/filter/game-doomchex/zscript/statusbars/main.zs
+++ b/filter/game-doomchex/zscript/statusbars/main.zs
@@ -3,18 +3,19 @@ Class SpecialDoomStatusBar : DoomStatusBar
 	transient CVar splitHUD;
 	transient CVar alphaValue;
 	transient CVar alphaOpaque;
-	
+
 	transient CVAR boomColors;
 	transient CVAR splitArms;
 	transient CVAR invReplace;
 	transient CVAR berserkShow;
 	transient CVAR chexArms;
 	transient CVAR automapHide;
-	
+
 	transient CVAR statsType;
 	transient CVAR statsFont;
 	transient CVAR statsCompColor;
 	transient CVAR statsShort;
+	transient CVAR statsCozy;
 	transient CVAR statKills;
 	transient CVAR statSecrets;
 	transient CVAR statItems;
@@ -27,7 +28,7 @@ Class SpecialDoomStatusBar : DoomStatusBar
 	InventoryBarState diparms_sbar;
 	HUDFont mSmallFont;
 	HUDFont mIndexFontF;
-	
+
 	// A hash to identify which STBAR is loaded
 	Name STBAR_HASH;
 
@@ -58,22 +59,23 @@ Class SpecialDoomStatusBar : DoomStatusBar
 	override void Init()
 	{
 		Super.Init();
-		
+
 		splitHUD    = CVar.FindCVar("fullhud_split");
 		alphaValue  = CVar.FindCVar("fullhud_trans");
 		alphaOpaque = CVar.FindCVar("fullhud_opaque");
-		
+
 		boomColors  = CVar.FindCVar("fullhud_boomcolors");
 		splitArms   = CVar.FindCVar("fullhud_splitarms");
 		invReplace  = CVar.FindCVar("fullhud_invovermug");
 		berserkShow = CVar.FindCVar("fullhud_showberserk");
 		chexArms    = CVar.FindCVar("fullhud_chexarms");
 		automapHide = CVar.FindCVar("fullhud_automaphide");
-		
+
 		statsType      = CVar.FindCVar("fullhud_stats_type");
 		statsFont      = CVar.FindCVar("fullhud_stats_font");
 		statsCompColor = CVar.FindCVar("fullhud_stats_comp");
 		statsShort     = CVar.FindCVar("fullhud_stats_short");
+		statsCozy      = CVar.FindCVar("fullhud_stats_cozy");
 		statKills      = CVar.FindCVar("fullhud_stats_kills");
 		statSecrets    = CVar.FindCVar("fullhud_stats_secrets");
 		statItems      = CVar.FindCVar("fullhud_stats_items");
@@ -83,7 +85,7 @@ Class SpecialDoomStatusBar : DoomStatusBar
 		borderless     = CVar.FindCVar("win_borderless");
 
 		diparms_sbar = InventoryBarState.CreateNoBox(mIndexFont, boxsize:(31, 31), arrowoffs:(0,-10));
-		
+
 		mSmallFont = HUDFont.Create(SmallFont, SmallFont.GetCharWidth("0"), Mono_CellCenter, 1, 1);
 		mIndexFontF = mIndexFont;
 		// Chex has a really weird font
@@ -91,7 +93,7 @@ Class SpecialDoomStatusBar : DoomStatusBar
 		{
 			Font fnt = "HUDFONT_DOOM";
 			mHUDFont = HUDFont.Create(fnt, fnt.GetCharWidth("0"), Mono_CellCenter, 0, 0);
-			
+
 			fnt = "INDEXFONT_CHEX";
 			mIndexFontF = HUDFont.Create(fnt, fnt.GetCharWidth("0"), Mono_CellLeft);
 		}
@@ -116,7 +118,7 @@ Class SpecialDoomStatusBar : DoomStatusBar
 	override void NewGame()
 	{
 		Super.NewGame();
-		
+
 		PowerupNames.clear();
 		PowerupDisplay.clear();
 		statNewGame();
@@ -136,7 +138,7 @@ Class SpecialDoomStatusBar : DoomStatusBar
 		StatFont sfnt;
 		getStatFont(sfnt);
 		if(PowerupNames.size() == 0) setPowerupNames();
-		
+
 		if (state == HUD_StatusBar)
 		{
 			if(!(automapactive && automapHide.GetInt()))
@@ -195,7 +197,7 @@ Class SpecialDoomStatusBar : DoomStatusBar
 	{
 		return string.format("%s%s",s1,s2);
 	}
-	
+
 	// ========================
 	// Get texture width easily
 	// ========================

--- a/filter/game-doomchex/zscript/statusbars/main.zs
+++ b/filter/game-doomchex/zscript/statusbars/main.zs
@@ -3,19 +3,18 @@ Class SpecialDoomStatusBar : DoomStatusBar
 	transient CVar splitHUD;
 	transient CVar alphaValue;
 	transient CVar alphaOpaque;
-
+	
 	transient CVAR boomColors;
 	transient CVAR splitArms;
 	transient CVAR invReplace;
 	transient CVAR berserkShow;
 	transient CVAR chexArms;
 	transient CVAR automapHide;
-
+	
 	transient CVAR statsType;
 	transient CVAR statsFont;
 	transient CVAR statsCompColor;
 	transient CVAR statsShort;
-	transient CVAR statsCozy;
 	transient CVAR statKills;
 	transient CVAR statSecrets;
 	transient CVAR statItems;
@@ -28,7 +27,7 @@ Class SpecialDoomStatusBar : DoomStatusBar
 	InventoryBarState diparms_sbar;
 	HUDFont mSmallFont;
 	HUDFont mIndexFontF;
-
+	
 	// A hash to identify which STBAR is loaded
 	Name STBAR_HASH;
 
@@ -59,23 +58,22 @@ Class SpecialDoomStatusBar : DoomStatusBar
 	override void Init()
 	{
 		Super.Init();
-
+		
 		splitHUD    = CVar.FindCVar("fullhud_split");
 		alphaValue  = CVar.FindCVar("fullhud_trans");
 		alphaOpaque = CVar.FindCVar("fullhud_opaque");
-
+		
 		boomColors  = CVar.FindCVar("fullhud_boomcolors");
 		splitArms   = CVar.FindCVar("fullhud_splitarms");
 		invReplace  = CVar.FindCVar("fullhud_invovermug");
 		berserkShow = CVar.FindCVar("fullhud_showberserk");
 		chexArms    = CVar.FindCVar("fullhud_chexarms");
 		automapHide = CVar.FindCVar("fullhud_automaphide");
-
+		
 		statsType      = CVar.FindCVar("fullhud_stats_type");
 		statsFont      = CVar.FindCVar("fullhud_stats_font");
 		statsCompColor = CVar.FindCVar("fullhud_stats_comp");
 		statsShort     = CVar.FindCVar("fullhud_stats_short");
-		statsCozy      = CVar.FindCVar("fullhud_stats_cozy");
 		statKills      = CVar.FindCVar("fullhud_stats_kills");
 		statSecrets    = CVar.FindCVar("fullhud_stats_secrets");
 		statItems      = CVar.FindCVar("fullhud_stats_items");
@@ -85,7 +83,7 @@ Class SpecialDoomStatusBar : DoomStatusBar
 		borderless     = CVar.FindCVar("win_borderless");
 
 		diparms_sbar = InventoryBarState.CreateNoBox(mIndexFont, boxsize:(31, 31), arrowoffs:(0,-10));
-
+		
 		mSmallFont = HUDFont.Create(SmallFont, SmallFont.GetCharWidth("0"), Mono_CellCenter, 1, 1);
 		mIndexFontF = mIndexFont;
 		// Chex has a really weird font
@@ -93,7 +91,7 @@ Class SpecialDoomStatusBar : DoomStatusBar
 		{
 			Font fnt = "HUDFONT_DOOM";
 			mHUDFont = HUDFont.Create(fnt, fnt.GetCharWidth("0"), Mono_CellCenter, 0, 0);
-
+			
 			fnt = "INDEXFONT_CHEX";
 			mIndexFontF = HUDFont.Create(fnt, fnt.GetCharWidth("0"), Mono_CellLeft);
 		}
@@ -118,7 +116,7 @@ Class SpecialDoomStatusBar : DoomStatusBar
 	override void NewGame()
 	{
 		Super.NewGame();
-
+		
 		PowerupNames.clear();
 		PowerupDisplay.clear();
 		statNewGame();
@@ -138,7 +136,7 @@ Class SpecialDoomStatusBar : DoomStatusBar
 		StatFont sfnt;
 		getStatFont(sfnt);
 		if(PowerupNames.size() == 0) setPowerupNames();
-
+		
 		if (state == HUD_StatusBar)
 		{
 			if(!(automapactive && automapHide.GetInt()))
@@ -197,7 +195,7 @@ Class SpecialDoomStatusBar : DoomStatusBar
 	{
 		return string.format("%s%s",s1,s2);
 	}
-
+	
 	// ========================
 	// Get texture width easily
 	// ========================

--- a/filter/game-doomchex/zscript/statusbars/main.zs
+++ b/filter/game-doomchex/zscript/statusbars/main.zs
@@ -1,16 +1,17 @@
 Class SpecialDoomStatusBar : DoomStatusBar
 {
+	transient CVar screenSize;
 	transient CVar splitHUD;
 	transient CVar alphaValue;
 	transient CVar alphaOpaque;
-	
+
 	transient CVAR boomColors;
 	transient CVAR splitArms;
 	transient CVAR invReplace;
 	transient CVAR berserkShow;
 	transient CVAR chexArms;
 	transient CVAR automapHide;
-	
+
 	transient CVAR statsType;
 	transient CVAR statsFont;
 	transient CVAR statsCompColor;
@@ -27,7 +28,7 @@ Class SpecialDoomStatusBar : DoomStatusBar
 	InventoryBarState diparms_sbar;
 	HUDFont mSmallFont;
 	HUDFont mIndexFontF;
-	
+
 	// A hash to identify which STBAR is loaded
 	Name STBAR_HASH;
 
@@ -58,18 +59,19 @@ Class SpecialDoomStatusBar : DoomStatusBar
 	override void Init()
 	{
 		Super.Init();
-		
+
+		screenSize  = CVar.FindCVar("screenblocks");
 		splitHUD    = CVar.FindCVar("fullhud_split");
 		alphaValue  = CVar.FindCVar("fullhud_trans");
 		alphaOpaque = CVar.FindCVar("fullhud_opaque");
-		
+
 		boomColors  = CVar.FindCVar("fullhud_boomcolors");
 		splitArms   = CVar.FindCVar("fullhud_splitarms");
 		invReplace  = CVar.FindCVar("fullhud_invovermug");
 		berserkShow = CVar.FindCVar("fullhud_showberserk");
 		chexArms    = CVar.FindCVar("fullhud_chexarms");
 		automapHide = CVar.FindCVar("fullhud_automaphide");
-		
+
 		statsType      = CVar.FindCVar("fullhud_stats_type");
 		statsFont      = CVar.FindCVar("fullhud_stats_font");
 		statsCompColor = CVar.FindCVar("fullhud_stats_comp");
@@ -83,7 +85,7 @@ Class SpecialDoomStatusBar : DoomStatusBar
 		borderless     = CVar.FindCVar("win_borderless");
 
 		diparms_sbar = InventoryBarState.CreateNoBox(mIndexFont, boxsize:(31, 31), arrowoffs:(0,-10));
-		
+
 		mSmallFont = HUDFont.Create(SmallFont, SmallFont.GetCharWidth("0"), Mono_CellCenter, 1, 1);
 		mIndexFontF = mIndexFont;
 		// Chex has a really weird font
@@ -91,7 +93,7 @@ Class SpecialDoomStatusBar : DoomStatusBar
 		{
 			Font fnt = "HUDFONT_DOOM";
 			mHUDFont = HUDFont.Create(fnt, fnt.GetCharWidth("0"), Mono_CellCenter, 0, 0);
-			
+
 			fnt = "INDEXFONT_CHEX";
 			mIndexFontF = HUDFont.Create(fnt, fnt.GetCharWidth("0"), Mono_CellLeft);
 		}
@@ -116,7 +118,7 @@ Class SpecialDoomStatusBar : DoomStatusBar
 	override void NewGame()
 	{
 		Super.NewGame();
-		
+
 		PowerupNames.clear();
 		PowerupDisplay.clear();
 		statNewGame();
@@ -136,7 +138,7 @@ Class SpecialDoomStatusBar : DoomStatusBar
 		StatFont sfnt;
 		getStatFont(sfnt);
 		if(PowerupNames.size() == 0) setPowerupNames();
-		
+
 		if (state == HUD_StatusBar)
 		{
 			if(!(automapactive && automapHide.GetInt()))
@@ -195,7 +197,7 @@ Class SpecialDoomStatusBar : DoomStatusBar
 	{
 		return string.format("%s%s",s1,s2);
 	}
-	
+
 	// ========================
 	// Get texture width easily
 	// ========================

--- a/filter/heretic/zscript/statusbars/main.zs
+++ b/filter/heretic/zscript/statusbars/main.zs
@@ -3,15 +3,16 @@ Class SpecialHereticStatusBar : HereticStatusBar
 	transient CVar splitHUD;
 	transient CVar alphaValue;
 	transient CVar alphaOpaque;
-	
+
 	transient CVAR boomColors;
 	transient CVAR splitArms;
 	transient CVAR automapHide;
-	
+
 	transient CVAR statsType;
 	transient CVAR statsFont;
 	transient CVAR statsCompColor;
-        transient CVAR statsShort;
+	transient CVAR statsShort;
+	transient CVAR statsCozy;
 	transient CVAR statKills;
 	transient CVAR statSecrets;
 	transient CVAR statItems;
@@ -45,23 +46,24 @@ Class SpecialHereticStatusBar : HereticStatusBar
 		OP_NUM = 1,
 		OP_NUMGRAPH = 2,
 	}
-	
+
 	override void Init()
 	{
 		Super.Init();
-		
+
 		splitHUD    = CVar.FindCVar("fullhud_split");
 		alphaValue  = CVar.FindCVar("fullhud_trans");
 		alphaOpaque = CVar.FindCVar("fullhud_opaque");
-		
+
 		boomColors  = CVar.FindCVar("fullhud_boomcolors");
 		splitArms   = CVar.FindCVar("fullhud_splitarms");
 		automapHide = CVar.FindCVar("fullhud_automaphide");
-		
+
 		statsType      = CVar.FindCVar("fullhud_stats_type");
 		statsFont      = CVar.FindCVar("fullhud_stats_font");
 		statsCompColor = CVar.FindCVar("fullhud_stats_comp");
 		statsShort     = CVar.FindCVar("fullhud_stats_short");
+		statsCozy      = CVar.FindCVar("fullhud_stats_cozy");
 		statKills      = CVar.FindCVar("fullhud_stats_kills");
 		statSecrets    = CVar.FindCVar("fullhud_stats_secrets");
 		statItems      = CVar.FindCVar("fullhud_stats_items");
@@ -97,7 +99,7 @@ Class SpecialHereticStatusBar : HereticStatusBar
 		PowerupDisplay.clear();
 		statNewGame();
 	}
-	
+
 	override void Tick()
 	{
 		Super.Tick();
@@ -115,7 +117,7 @@ Class SpecialHereticStatusBar : HereticStatusBar
 	override void Draw (int state, double TicFrac)
 	{
 		BaseStatusBar.Draw (state, TicFrac);
-		
+
 		StatFont sfnt;
 		getStatFont(sfnt);
 		if(PowerupNames.size() == 0) setPowerupNames();
@@ -155,7 +157,7 @@ Class SpecialHereticStatusBar : HereticStatusBar
 	{
 		return string.format("%s%s",s1,s2);
 	}
-	
+
 	// ========================
 	// Get texture width easily
 	// ========================

--- a/filter/heretic/zscript/statusbars/main.zs
+++ b/filter/heretic/zscript/statusbars/main.zs
@@ -1,13 +1,14 @@
 Class SpecialHereticStatusBar : HereticStatusBar
 {
+	transient CVar screenSize;
 	transient CVar splitHUD;
 	transient CVar alphaValue;
 	transient CVar alphaOpaque;
-	
+
 	transient CVAR boomColors;
 	transient CVAR splitArms;
 	transient CVAR automapHide;
-	
+
 	transient CVAR statsType;
 	transient CVAR statsFont;
 	transient CVAR statsCompColor;
@@ -45,19 +46,20 @@ Class SpecialHereticStatusBar : HereticStatusBar
 		OP_NUM = 1,
 		OP_NUMGRAPH = 2,
 	}
-	
+
 	override void Init()
 	{
 		Super.Init();
-		
+
+		screenSize  = CVar.FindCVar("screenblocks");
 		splitHUD    = CVar.FindCVar("fullhud_split");
 		alphaValue  = CVar.FindCVar("fullhud_trans");
 		alphaOpaque = CVar.FindCVar("fullhud_opaque");
-		
+
 		boomColors  = CVar.FindCVar("fullhud_boomcolors");
 		splitArms   = CVar.FindCVar("fullhud_splitarms");
 		automapHide = CVar.FindCVar("fullhud_automaphide");
-		
+
 		statsType      = CVar.FindCVar("fullhud_stats_type");
 		statsFont      = CVar.FindCVar("fullhud_stats_font");
 		statsCompColor = CVar.FindCVar("fullhud_stats_comp");
@@ -97,7 +99,7 @@ Class SpecialHereticStatusBar : HereticStatusBar
 		PowerupDisplay.clear();
 		statNewGame();
 	}
-	
+
 	override void Tick()
 	{
 		Super.Tick();
@@ -115,7 +117,7 @@ Class SpecialHereticStatusBar : HereticStatusBar
 	override void Draw (int state, double TicFrac)
 	{
 		BaseStatusBar.Draw (state, TicFrac);
-		
+
 		StatFont sfnt;
 		getStatFont(sfnt);
 		if(PowerupNames.size() == 0) setPowerupNames();
@@ -155,7 +157,7 @@ Class SpecialHereticStatusBar : HereticStatusBar
 	{
 		return string.format("%s%s",s1,s2);
 	}
-	
+
 	// ========================
 	// Get texture width easily
 	// ========================

--- a/filter/heretic/zscript/statusbars/main.zs
+++ b/filter/heretic/zscript/statusbars/main.zs
@@ -3,16 +3,15 @@ Class SpecialHereticStatusBar : HereticStatusBar
 	transient CVar splitHUD;
 	transient CVar alphaValue;
 	transient CVar alphaOpaque;
-
+	
 	transient CVAR boomColors;
 	transient CVAR splitArms;
 	transient CVAR automapHide;
-
+	
 	transient CVAR statsType;
 	transient CVAR statsFont;
 	transient CVAR statsCompColor;
-	transient CVAR statsShort;
-	transient CVAR statsCozy;
+        transient CVAR statsShort;
 	transient CVAR statKills;
 	transient CVAR statSecrets;
 	transient CVAR statItems;
@@ -46,24 +45,23 @@ Class SpecialHereticStatusBar : HereticStatusBar
 		OP_NUM = 1,
 		OP_NUMGRAPH = 2,
 	}
-
+	
 	override void Init()
 	{
 		Super.Init();
-
+		
 		splitHUD    = CVar.FindCVar("fullhud_split");
 		alphaValue  = CVar.FindCVar("fullhud_trans");
 		alphaOpaque = CVar.FindCVar("fullhud_opaque");
-
+		
 		boomColors  = CVar.FindCVar("fullhud_boomcolors");
 		splitArms   = CVar.FindCVar("fullhud_splitarms");
 		automapHide = CVar.FindCVar("fullhud_automaphide");
-
+		
 		statsType      = CVar.FindCVar("fullhud_stats_type");
 		statsFont      = CVar.FindCVar("fullhud_stats_font");
 		statsCompColor = CVar.FindCVar("fullhud_stats_comp");
 		statsShort     = CVar.FindCVar("fullhud_stats_short");
-		statsCozy      = CVar.FindCVar("fullhud_stats_cozy");
 		statKills      = CVar.FindCVar("fullhud_stats_kills");
 		statSecrets    = CVar.FindCVar("fullhud_stats_secrets");
 		statItems      = CVar.FindCVar("fullhud_stats_items");
@@ -99,7 +97,7 @@ Class SpecialHereticStatusBar : HereticStatusBar
 		PowerupDisplay.clear();
 		statNewGame();
 	}
-
+	
 	override void Tick()
 	{
 		Super.Tick();
@@ -117,7 +115,7 @@ Class SpecialHereticStatusBar : HereticStatusBar
 	override void Draw (int state, double TicFrac)
 	{
 		BaseStatusBar.Draw (state, TicFrac);
-
+		
 		StatFont sfnt;
 		getStatFont(sfnt);
 		if(PowerupNames.size() == 0) setPowerupNames();
@@ -157,7 +155,7 @@ Class SpecialHereticStatusBar : HereticStatusBar
 	{
 		return string.format("%s%s",s1,s2);
 	}
-
+	
 	// ========================
 	// Get texture width easily
 	// ========================

--- a/filter/hexen/zscript/statusbars/main.zs
+++ b/filter/hexen/zscript/statusbars/main.zs
@@ -3,17 +3,16 @@ Class SpecialHexenStatusBar : HexenStatusBar
 	transient CVar splitHUD;
 	transient CVar alphaValue;
 	transient CVar alphaOpaque;
-
+	
 	transient CVAR boomColors;
 	transient CVAR splitArms;
 	transient CVAR armorPoints;
 	transient CVAR automapHide;
-
+	
 	transient CVAR statsType;
 	transient CVAR statsFont;
 	transient CVAR statsCompColor;
 	transient CVAR statsShort;
-	transient CVAR statsCozy;
 	transient CVAR statKills;
 	transient CVAR statSecrets;
 	transient CVAR statItems;
@@ -37,25 +36,24 @@ Class SpecialHexenStatusBar : HexenStatusBar
 		OP_NUM = 1,
 		OP_NUMGRAPH = 2,
 	}
-
+	
 	override void Init()
 	{
 		Super.Init();
-
+		
 		splitHUD    = CVar.FindCVar("fullhud_split");
 		alphaValue  = CVar.FindCVar("fullhud_trans");
 		alphaOpaque = CVar.FindCVar("fullhud_opaque");
-
+		
 		boomColors  = CVar.FindCVar("fullhud_boomcolors");
 		splitArms   = CVar.FindCVar("fullhud_splitarms");
 		armorPoints = CVar.FindCVar("fullhud_armorpoints");
 		automapHide = CVar.FindCVar("fullhud_automaphide");
-
+		
 		statsType      = CVar.FindCVar("fullhud_stats_type");
 		statsFont      = CVar.FindCVar("fullhud_stats_font");
 		statsCompColor = CVar.FindCVar("fullhud_stats_comp");
 		statsShort     = CVar.FindCVar("fullhud_stats_short");
-		statsCozy      = CVar.FindCVar("fullhud_stats_cozy");
 		statKills      = CVar.FindCVar("fullhud_stats_kills");
 		statSecrets    = CVar.FindCVar("fullhud_stats_secrets");
 		statItems      = CVar.FindCVar("fullhud_stats_items");
@@ -96,11 +94,11 @@ Class SpecialHexenStatusBar : HexenStatusBar
 	override void Draw (int state, double TicFrac)
 	{
 		BaseStatusBar.Draw (state, TicFrac);
-
+		
 		StatFont sfnt;
 		getStatFont(sfnt);
 		if(PowerupNames.size() == 0) setPowerupNames();
-
+		
 		if (state == HUD_StatusBar)
 		{
 			if(!(automapactive && automapHide.GetInt()))
@@ -140,7 +138,7 @@ Class SpecialHexenStatusBar : HexenStatusBar
 	{
 		return string.format("%s%s",s1,s2);
 	}
-
+	
 	// ========================
 	// Get texture width easily
 	// ========================

--- a/filter/hexen/zscript/statusbars/main.zs
+++ b/filter/hexen/zscript/statusbars/main.zs
@@ -1,14 +1,15 @@
 Class SpecialHexenStatusBar : HexenStatusBar
 {
+	transient CVar screenSize;
 	transient CVar splitHUD;
 	transient CVar alphaValue;
 	transient CVar alphaOpaque;
-	
+
 	transient CVAR boomColors;
 	transient CVAR splitArms;
 	transient CVAR armorPoints;
 	transient CVAR automapHide;
-	
+
 	transient CVAR statsType;
 	transient CVAR statsFont;
 	transient CVAR statsCompColor;
@@ -36,20 +37,21 @@ Class SpecialHexenStatusBar : HexenStatusBar
 		OP_NUM = 1,
 		OP_NUMGRAPH = 2,
 	}
-	
+
 	override void Init()
 	{
 		Super.Init();
-		
+
+		screenSize  = CVar.FindCVar("screenblocks");
 		splitHUD    = CVar.FindCVar("fullhud_split");
 		alphaValue  = CVar.FindCVar("fullhud_trans");
 		alphaOpaque = CVar.FindCVar("fullhud_opaque");
-		
+
 		boomColors  = CVar.FindCVar("fullhud_boomcolors");
 		splitArms   = CVar.FindCVar("fullhud_splitarms");
 		armorPoints = CVar.FindCVar("fullhud_armorpoints");
 		automapHide = CVar.FindCVar("fullhud_automaphide");
-		
+
 		statsType      = CVar.FindCVar("fullhud_stats_type");
 		statsFont      = CVar.FindCVar("fullhud_stats_font");
 		statsCompColor = CVar.FindCVar("fullhud_stats_comp");
@@ -94,11 +96,11 @@ Class SpecialHexenStatusBar : HexenStatusBar
 	override void Draw (int state, double TicFrac)
 	{
 		BaseStatusBar.Draw (state, TicFrac);
-		
+
 		StatFont sfnt;
 		getStatFont(sfnt);
 		if(PowerupNames.size() == 0) setPowerupNames();
-		
+
 		if (state == HUD_StatusBar)
 		{
 			if(!(automapactive && automapHide.GetInt()))
@@ -138,7 +140,7 @@ Class SpecialHexenStatusBar : HexenStatusBar
 	{
 		return string.format("%s%s",s1,s2);
 	}
-	
+
 	// ========================
 	// Get texture width easily
 	// ========================

--- a/filter/hexen/zscript/statusbars/main.zs
+++ b/filter/hexen/zscript/statusbars/main.zs
@@ -3,16 +3,17 @@ Class SpecialHexenStatusBar : HexenStatusBar
 	transient CVar splitHUD;
 	transient CVar alphaValue;
 	transient CVar alphaOpaque;
-	
+
 	transient CVAR boomColors;
 	transient CVAR splitArms;
 	transient CVAR armorPoints;
 	transient CVAR automapHide;
-	
+
 	transient CVAR statsType;
 	transient CVAR statsFont;
 	transient CVAR statsCompColor;
 	transient CVAR statsShort;
+	transient CVAR statsCozy;
 	transient CVAR statKills;
 	transient CVAR statSecrets;
 	transient CVAR statItems;
@@ -36,24 +37,25 @@ Class SpecialHexenStatusBar : HexenStatusBar
 		OP_NUM = 1,
 		OP_NUMGRAPH = 2,
 	}
-	
+
 	override void Init()
 	{
 		Super.Init();
-		
+
 		splitHUD    = CVar.FindCVar("fullhud_split");
 		alphaValue  = CVar.FindCVar("fullhud_trans");
 		alphaOpaque = CVar.FindCVar("fullhud_opaque");
-		
+
 		boomColors  = CVar.FindCVar("fullhud_boomcolors");
 		splitArms   = CVar.FindCVar("fullhud_splitarms");
 		armorPoints = CVar.FindCVar("fullhud_armorpoints");
 		automapHide = CVar.FindCVar("fullhud_automaphide");
-		
+
 		statsType      = CVar.FindCVar("fullhud_stats_type");
 		statsFont      = CVar.FindCVar("fullhud_stats_font");
 		statsCompColor = CVar.FindCVar("fullhud_stats_comp");
 		statsShort     = CVar.FindCVar("fullhud_stats_short");
+		statsCozy      = CVar.FindCVar("fullhud_stats_cozy");
 		statKills      = CVar.FindCVar("fullhud_stats_kills");
 		statSecrets    = CVar.FindCVar("fullhud_stats_secrets");
 		statItems      = CVar.FindCVar("fullhud_stats_items");
@@ -94,11 +96,11 @@ Class SpecialHexenStatusBar : HexenStatusBar
 	override void Draw (int state, double TicFrac)
 	{
 		BaseStatusBar.Draw (state, TicFrac);
-		
+
 		StatFont sfnt;
 		getStatFont(sfnt);
 		if(PowerupNames.size() == 0) setPowerupNames();
-		
+
 		if (state == HUD_StatusBar)
 		{
 			if(!(automapactive && automapHide.GetInt()))
@@ -138,7 +140,7 @@ Class SpecialHexenStatusBar : HexenStatusBar
 	{
 		return string.format("%s%s",s1,s2);
 	}
-	
+
 	// ========================
 	// Get texture width easily
 	// ========================

--- a/language.enu
+++ b/language.enu
@@ -29,8 +29,8 @@ FULLHUD_LSP_CL  = "Center left";
 FULLHUD_LSP_CR  = "Center right";
 FULLHUD_LSP_BL  = "Bottom left";
 FULLHUD_LSP_BR  = "Bottom right";
-FULLHUD_LSP_SBL = "Status Bar (Left)";
-FULLHUD_LSP_SBR = "Status Bar (Right)";
+FULLHUD_LSP_SBL = "Status Bar left";
+FULLHUD_LSP_SBR = "Status Bar right";
 
 // OptionValue "Colors"
 // OPTVAL_NONE = "None";

--- a/language.enu
+++ b/language.enu
@@ -117,6 +117,7 @@ FULLHUD_STATS_ITEMS       = "Items counter";
 FULLHUD_STATS_LEVELTIME   = "Level time";
 FULLHUD_STATS_POWERUPS    = "Powerup timers";
 FULLHUD_STATS_SHORT       = "Abbreviate stats";
+FULLHUD_STATS_COZY        = "Adjacent to Status Bar";
 
 FULLHUD_STATSTOOLTIP_STATDISPLAY      = "Choose a system for kill/secret/item counters (e.g.: '50%', '6 Left' or '6/12')";
 FULLHUD_STATSTOOLTIP_STATDISPLAY_CHEX = "Choose a system for zorch/secret/item counters (e.g.: '50%', '6 Left' or '6/12')";
@@ -130,6 +131,7 @@ FULLHUD_STATSTOOLTIP_LEVELTIME        = "Show time spent in a level";
 FULLHUD_STATSTOOLTIP_SECRETS          = "Show amount of found secrets";
 FULLHUD_STATSTOOLTIP_POWERUPS         = "Show duration of activated powerups";
 FULLHUD_STATSTOOLTIP_SHORT            = "Only show first letter of stats names (e.g.: 'S' instead of 'Secrets')";
+FULLHUD_STATSTOOLTIP_COZY             = "Place the stats closer to the Status Bar (Split Bar must be OFF)";
 
 /* --- Stat Display --- */
 FULLHUD_KILLS            = "Kills";

--- a/language.enu
+++ b/language.enu
@@ -29,6 +29,8 @@ FULLHUD_LSP_CL  = "Center left";
 FULLHUD_LSP_CR  = "Center right";
 FULLHUD_LSP_BL  = "Bottom left";
 FULLHUD_LSP_BR  = "Bottom right";
+FULLHUD_LSP_SBL = "Status Bar (Left)";
+FULLHUD_LSP_SBR = "Status Bar (Right)";
 
 // OptionValue "Colors"
 // OPTVAL_NONE = "None";

--- a/language.enu
+++ b/language.enu
@@ -117,7 +117,6 @@ FULLHUD_STATS_ITEMS       = "Items counter";
 FULLHUD_STATS_LEVELTIME   = "Level time";
 FULLHUD_STATS_POWERUPS    = "Powerup timers";
 FULLHUD_STATS_SHORT       = "Abbreviate stats";
-FULLHUD_STATS_COZY        = "Adjacent to Status Bar";
 
 FULLHUD_STATSTOOLTIP_STATDISPLAY      = "Choose a system for kill/secret/item counters (e.g.: '50%', '6 Left' or '6/12')";
 FULLHUD_STATSTOOLTIP_STATDISPLAY_CHEX = "Choose a system for zorch/secret/item counters (e.g.: '50%', '6 Left' or '6/12')";
@@ -131,7 +130,6 @@ FULLHUD_STATSTOOLTIP_LEVELTIME        = "Show time spent in a level";
 FULLHUD_STATSTOOLTIP_SECRETS          = "Show amount of found secrets";
 FULLHUD_STATSTOOLTIP_POWERUPS         = "Show duration of activated powerups";
 FULLHUD_STATSTOOLTIP_SHORT            = "Only show first letter of stats names (e.g.: 'S' instead of 'Secrets')";
-FULLHUD_STATSTOOLTIP_COZY             = "Place the stats closer to the Status Bar (Split Bar must be OFF)";
 
 /* --- Stat Display --- */
 FULLHUD_KILLS            = "Kills";

--- a/menudef
+++ b/menudef
@@ -1,5 +1,5 @@
 AddOptionMenu "HUDOptions" after "AltHUDOptions"
-{   
+{
 	Submenu "$FULLHUD_MODTITLE", "FullscreenStatusbarOptions"
 }
 
@@ -76,6 +76,12 @@ OptionValue "BerserkCross"
 	2, "$C_GREEN"
 }
 
+OptionValue "CozyMode"
+{
+	0, "$OPTVAL_OFF"
+	1, "$OPTVAL_ON"
+}
+
 OptionMenu "FullscreenStatusbarOptions"
 {
 	Title "$FULLHUD_MODTITLE"
@@ -111,17 +117,17 @@ OptionMenu "OptionalSettings"
 
 	StaticText ""
 	FullHUDOption "$FULLHUD_OPTIONAL_BOOMHUD",              "$FULLHUD_OPTIONALTOOLTIP_BOOMHUD",     "fullhud_boomcolors", "OnOff", "", 0, 0
-	IfGame(Doom) 
+	IfGame(Doom)
 	{
 		FullHUDOption "$FULLHUD_OPTIONAL_BERSERK",      "$FULLHUD_OPTIONALTOOLTIP_BERSERK",     "fullhud_showberserk", "BerserkCross"
 	}
-	IfGame(Chex) 
+	IfGame(Chex)
 	{
 		FullHUDOption "$FULLHUD_OPTIONAL_CHEXLOGO",     "$FULLHUD_OPTIONALTOOLTIP_CHEXLOGO",     "fullhud_chexarms", "OnOff"
 	}
 	FullHUDOption "$FULLHUD_OPTIONAL_SPLITARMS",            "$FULLHUD_OPTIONALTOOLTIP_SPLITARMS",    "fullhud_splitarms", "OnOff", "fullhud_split"
-	IfGame(Doom, Chex) 
-	{	
+	IfGame(Doom, Chex)
+	{
 		FullHUDOption "$FULLHUD_OPTIONAL_INVREPLACE",   "$FULLHUD_OPTIONALTOOLTIP_INVREPLACE",   "fullhud_invovermug", "OnOff"
 	}
  	IfGame(Hexen)
@@ -174,6 +180,7 @@ OptionMenu "StatsSettings"
 	FullHUDOption         "$FULLHUD_STATS_LEVELTIME",  "$FULLHUD_STATSTOOLTIP_LEVELTIME",   "fullhud_stats_time",     "LevelStatsPosition", "fullhud_stats_type"
 	FullHUDOption         "$FULLHUD_STATS_POWERUPS",   "$FULLHUD_STATSTOOLTIP_POWERUPS",    "fullhud_stats_powerups", "LevelStatsPosition", "fullhud_stats_type"
 	FullHUDOption 	      "$FULLHUD_STATS_SHORT",      "$FULLHUD_STATSTOOLTIP_SHORT",       "fullhud_stats_short",    "OnOff"
+	FullHUDOption 	      "$FULLHUD_STATS_COZY",       "$FULLHUD_STATSTOOLTIP_COZY",        "fullhud_stats_cozy",     "OnOff"
 }
 
 ListMenu "FullscreenCredits"
@@ -182,26 +189,32 @@ ListMenu "FullscreenCredits"
 	StaticText -32,	  6, "Version 5.1.12", gold
 	StaticText -32,	 18, "NightFright", red
 	StaticText  96,	 18, "Original SBARINFO coding / idea", green
-	StaticText -32,	 30, "3saster", red
-	StaticText  96,	 30, "ZScript coding", green
-	StaticText -32,	 54, "id Software", red
-	StaticText  96,	 54, "Original Doom GFX", green
-	StaticText -32,	 66, "Raven Software", red
-	StaticText  96,	 66, "Original Heretic/Hexen GFX", green
-	StaticText -32,	 90, "bangstk", red
-	StaticText  96,	 90, "Code for widescreen status bars", green
-	StaticText -32,	102, "DTDsphere", red
-	StaticText  96,	102, "Project initiator - special thanks!", green
-	StaticText -32,	114, "Jimmy", red
-	StaticText  96,	114, "'MemenTwo' and 'Status Report' fonts", green
-	StaticText -32,	126, "Kinsie", red
-	StaticText  96,	126, "Dystopia 3 compatibility", green
-	StaticText -32,	138, "m8f", red
-	StaticText  96,	138, "Split status bar for Doom", green
-	StaticText -32,	150, "MaxED", red
-	StaticText  96,	150, "Split status bars for Heretic/Hexen", green
-	StaticText -32,	162, "Nash Muhandes", red
-	StaticText  96,	162, "Raven status bars / menu tooltips", green
-	StaticText -32,	174, "Delfino Furioso", red
-	StaticText  96,	174, "Hexen compatibility code patches", green
+	StaticText -32,	 28, "3saster", red
+	StaticText  96,	 28, "ZScript coding", green
+	StaticText -32,	 38, "      --", red
+	StaticText  96,	 38, "       --", green
+	StaticText -32,	 48, "id Software", red
+	StaticText  96,	 48, "Original Doom GFX", green
+	StaticText -32,	 58, "Raven Software", red
+	StaticText  96,	 58, "Original Heretic/Hexen GFX", green
+	StaticText -32,	 68, "      --", red
+	StaticText  96,	 68, "       --", green
+	StaticText -32,	 78, "bangstk", red
+	StaticText  96,	 78, "Code for widescreen status bars", green
+	StaticText -32,	 88, "DTDsphere", red
+	StaticText  96,	 88, "Project initiator - special thanks!", green
+	StaticText -32,  98, "Jimmy", red
+	StaticText  96,	 98, "'MemenTwo' and 'Status Report' fonts", green
+	StaticText -32,	108, "Kinsie", red
+	StaticText  96,	108, "Dystopia 3 compatibility", green
+	StaticText -32,	118, "m8f", red
+	StaticText  96,	118, "Split status bar for Doom", green
+	StaticText -32,	128, "MaxED", red
+	StaticText  96,	128, "Split status bars for Heretic/Hexen", green
+	StaticText -32,	138, "Nash Muhandes", red
+	StaticText  96,	138, "Raven status bars / menu tooltips", green
+	StaticText -32,	148, "Delfino Furioso", red
+	StaticText  96,	148, "Hexen compatibility code patches", green
+	StaticText -32,	158, "scar45", red
+	StaticText  96,	158, "Stats adjacent to non-split status bar", green
 }

--- a/menudef
+++ b/menudef
@@ -1,5 +1,5 @@
 AddOptionMenu "HUDOptions" after "AltHUDOptions"
-{   
+{
 	Submenu "$FULLHUD_MODTITLE", "FullscreenStatusbarOptions"
 }
 
@@ -34,6 +34,8 @@ OptionValue "LevelStatsPosition"
 	4, "$FULLHUD_LSP_CR"
 	5, "$FULLHUD_LSP_BL"
 	6, "$FULLHUD_LSP_BR"
+	7, "$FULLHUD_LSP_SBL"
+	8, "$FULLHUD_LSP_SBR"
 }
 
 OptionValue "Colors"
@@ -83,7 +85,7 @@ OptionMenu "FullscreenStatusbarOptions"
 	Submenu "$FULLHUD_SETTINGSNAME_GENERAL",  "GeneralSettings"
 	Submenu "$FULLHUD_SETTINGSNAME_OPTIONAL", "OptionalSettings"
 	Submenu "$FULLHUD_SETTINGSNAME_STATS",    "StatsSettings"
-   	StaticText ""
+	StaticText ""
 	Submenu "$FULLHUD_SETTINGSNAME_CREDITS",  "FullscreenCredits"
 }
 
@@ -111,17 +113,17 @@ OptionMenu "OptionalSettings"
 
 	StaticText ""
 	FullHUDOption "$FULLHUD_OPTIONAL_BOOMHUD",              "$FULLHUD_OPTIONALTOOLTIP_BOOMHUD",     "fullhud_boomcolors", "OnOff", "", 0, 0
-	IfGame(Doom) 
+	IfGame(Doom)
 	{
 		FullHUDOption "$FULLHUD_OPTIONAL_BERSERK",      "$FULLHUD_OPTIONALTOOLTIP_BERSERK",     "fullhud_showberserk", "BerserkCross"
 	}
-	IfGame(Chex) 
+	IfGame(Chex)
 	{
 		FullHUDOption "$FULLHUD_OPTIONAL_CHEXLOGO",     "$FULLHUD_OPTIONALTOOLTIP_CHEXLOGO",     "fullhud_chexarms", "OnOff"
 	}
 	FullHUDOption "$FULLHUD_OPTIONAL_SPLITARMS",            "$FULLHUD_OPTIONALTOOLTIP_SPLITARMS",    "fullhud_splitarms", "OnOff", "fullhud_split"
-	IfGame(Doom, Chex) 
-	{	
+	IfGame(Doom, Chex)
+	{
 		FullHUDOption "$FULLHUD_OPTIONAL_INVREPLACE",   "$FULLHUD_OPTIONALTOOLTIP_INVREPLACE",   "fullhud_invovermug", "OnOff"
 	}
  	IfGame(Hexen)
@@ -209,5 +211,5 @@ ListMenu "FullscreenCredits"
 	StaticText -32,	148, "Delfino Furioso", red
 	StaticText  96,	148, "Hexen compatibility code patches", green
 	StaticText -32,	158, "scar45", red
-	StaticText  96,	158, "Stats adjacent to non-split status bar", green
+	StaticText  96,	158, "Stats positioned next to status bar", green
 }

--- a/menudef
+++ b/menudef
@@ -211,5 +211,5 @@ ListMenu "FullscreenCredits"
 	StaticText -32,	148, "Delfino Furioso", red
 	StaticText  96,	148, "Hexen compatibility code patches", green
 	StaticText -32,	158, "scar45", red
-	StaticText  96,	158, "Stats positioned next to status bar", green
+	StaticText  96,	158, "Stats aligned next to status bar", green
 }

--- a/menudef
+++ b/menudef
@@ -1,5 +1,5 @@
 AddOptionMenu "HUDOptions" after "AltHUDOptions"
-{
+{   
 	Submenu "$FULLHUD_MODTITLE", "FullscreenStatusbarOptions"
 }
 
@@ -76,12 +76,6 @@ OptionValue "BerserkCross"
 	2, "$C_GREEN"
 }
 
-OptionValue "CozyMode"
-{
-	0, "$OPTVAL_OFF"
-	1, "$OPTVAL_ON"
-}
-
 OptionMenu "FullscreenStatusbarOptions"
 {
 	Title "$FULLHUD_MODTITLE"
@@ -117,17 +111,17 @@ OptionMenu "OptionalSettings"
 
 	StaticText ""
 	FullHUDOption "$FULLHUD_OPTIONAL_BOOMHUD",              "$FULLHUD_OPTIONALTOOLTIP_BOOMHUD",     "fullhud_boomcolors", "OnOff", "", 0, 0
-	IfGame(Doom)
+	IfGame(Doom) 
 	{
 		FullHUDOption "$FULLHUD_OPTIONAL_BERSERK",      "$FULLHUD_OPTIONALTOOLTIP_BERSERK",     "fullhud_showberserk", "BerserkCross"
 	}
-	IfGame(Chex)
+	IfGame(Chex) 
 	{
 		FullHUDOption "$FULLHUD_OPTIONAL_CHEXLOGO",     "$FULLHUD_OPTIONALTOOLTIP_CHEXLOGO",     "fullhud_chexarms", "OnOff"
 	}
 	FullHUDOption "$FULLHUD_OPTIONAL_SPLITARMS",            "$FULLHUD_OPTIONALTOOLTIP_SPLITARMS",    "fullhud_splitarms", "OnOff", "fullhud_split"
-	IfGame(Doom, Chex)
-	{
+	IfGame(Doom, Chex) 
+	{	
 		FullHUDOption "$FULLHUD_OPTIONAL_INVREPLACE",   "$FULLHUD_OPTIONALTOOLTIP_INVREPLACE",   "fullhud_invovermug", "OnOff"
 	}
  	IfGame(Hexen)
@@ -180,7 +174,6 @@ OptionMenu "StatsSettings"
 	FullHUDOption         "$FULLHUD_STATS_LEVELTIME",  "$FULLHUD_STATSTOOLTIP_LEVELTIME",   "fullhud_stats_time",     "LevelStatsPosition", "fullhud_stats_type"
 	FullHUDOption         "$FULLHUD_STATS_POWERUPS",   "$FULLHUD_STATSTOOLTIP_POWERUPS",    "fullhud_stats_powerups", "LevelStatsPosition", "fullhud_stats_type"
 	FullHUDOption 	      "$FULLHUD_STATS_SHORT",      "$FULLHUD_STATSTOOLTIP_SHORT",       "fullhud_stats_short",    "OnOff"
-	FullHUDOption 	      "$FULLHUD_STATS_COZY",       "$FULLHUD_STATSTOOLTIP_COZY",        "fullhud_stats_cozy",     "OnOff"
 }
 
 ListMenu "FullscreenCredits"

--- a/readme.txt
+++ b/readme.txt
@@ -13,8 +13,8 @@ Other files by author: Blinking Eyes for Doom Mugshot
                        Widescreen HUDs for Doom/Doom II PWADs
 
 Description          : Fullscreen versions for the status bars of Doom-based
-                       games (Doom, Doom II, Final Doom, Freedoom, Chex, HacX,
-                       Harmony), Heretic and Hexen with optional transparency
+                       games (Doom, Doom II, Final Doom, Freedoom, Chex, HacX, 
+                       Harmony), Heretic and Hexen with optional transparency 
                        and level stats display
 
 Additional Info      : 1) Only works with GZDoom 4.3.0+, LZDoom 3.84+ and other
@@ -44,11 +44,11 @@ Additional Info      : 1) Only works with GZDoom 4.3.0+, LZDoom 3.84+ and other
                                   + Choose between 22 different stat completion colors
                                   + Optionally show countdowns for active powerups
 				  + Optionally abbreviate stats names (K/I/S)
-                       5) Adds 15-17 CVARS to your GZDoom ini, starting with "fullhud_"
+                       5) Adds 15-17 CVARS to your GZDoom ini, starting with "fullhud_" 
 
-Known issues         : [CHEX] Logo replacement will only look good if default STBAR graphics
+Known issues         : [CHEX] Logo replacement will only look good if default STBAR graphics 
                               are used (with blue background)
-
+                       
 
 Additional Credits to: id Software .................. Original Doom GFX
                        Raven Software ............... Original Heretic/Hexen GFX
@@ -62,7 +62,6 @@ Additional Credits to: id Software .................. Original Doom GFX
                        Nash Muhandes ................ Widescreen Heretic/Hexen status bars
                                                       Menu tooltips
                        Delfino Furioso .............. Hexen compatibility code patches
-                       scar45 ....................... Stats adjacent to non-split status bar
 
 ===========================================================================
 * What is included *
@@ -102,7 +101,6 @@ Tested With          : GZDoom
 * CHANGELOG *
 
 > Version 5.1.12 (xx xx, 2022)
-  [ALL] Stats: Added option for placing adjacent to (non-split) Status Bar (code by scar45)
   [HEXEN] Compatibility with "Hexen Rebalanced" and "Tempered Arms" (code by Delfino Furioso)
 
 > Version 5.1.11 (Jun 7, 2022)
@@ -147,7 +145,7 @@ Tested With          : GZDoom
   [ALL] Stats: Can now choose between 25 (before: 3) different stat completion colors
 
 > Version 5.1.4 (Jan 7, 2020)
-  NOTE: Now requires GZDoom 4.3.0+ or LZDoom 3.84+. This is due to a major internal restructure that makes
+  NOTE: Now requires GZDoom 4.3.0+ or LZDoom 3.84+. This is due to a major internal restructure that makes 
         many parts of the code (especially stats) MUCH easier to maintain, using mixins
   [ALL] General Settings: "Force HUD override" option removed. This was rather hacky and caused crashes, even when turned off
   [ALL] Added tooltips to menu options
@@ -163,7 +161,7 @@ Tested With          : GZDoom
   NOTE: Now requires GZDoom 4.2.4+. This prevents a segfault that can occur with "Force HUD override" active.
         It is recommended to avoid activating this option in LZDoom (at least for now)
   [ALL] MENUDEF: Reorganization into submenus ("General Settings", "Optional Settings", "Stats")
-  [ALL] General Settings: "Force HUD override" option added. This will override any other custom HUD and
+  [ALL] General Settings: "Force HUD override" option added. This will override any other custom HUD and 
                           use this HUD instead, regardless of load order (intended for autoload in particular)
   [ALL] Stats: "Powerup timers" option added. Works exactly the same as in Tekish's LevelInfo v1.22 (for now)
   [ALL] Stats: Fixed top-right stats not moving correctly when the vid_fps CVAR is on
@@ -172,7 +170,7 @@ Tested With          : GZDoom
   [DOOM] Automatic compatibility added for Pirate Doom
   [CHEX] Berserk mode indicator CVAR from Doom no longer saved to ini
   [HACX] No longer uses modified STBAR lump, but instead adds a small black patch to cover mugshot background
-
+  
 > Version 5.1.2 (Nov 4, 2019)
   [ALL] MENUDEF: Code optimization (now only HacX needs two files, all other games just one)
   [DOOM] Automatic compatibility added for Sunlust
@@ -186,7 +184,7 @@ Tested With          : GZDoom
 
 > Version 5.1.0 (Oct 2, 2019)
   [DOOM] Automatic compatibility with selected PWADs which needed separate fixes before. Currently included:
-         Alien Vendetta, Avactor, Back to Saturn X Ep.1+2, Doom 4 Vanilla, Doom Neural Upscale 2X, Epic 2,
+         Alien Vendetta, Avactor, Back to Saturn X Ep.1+2, Doom 4 Vanilla, Doom Neural Upscale 2X, Epic 2, 
          Eviternity and Memento Mori 2
   [DOOM/CHEX/HACX/HARMONY] Inventory: Amount is now properly right-justified and moved to the correct spot
 
@@ -206,13 +204,13 @@ Tested With          : GZDoom
   [ALL] Level stats: Added option to change stats font. 5 choices available (default: font from 4.x releases)
 
 > Version 5.0 (Sep 4, 2019)
-  NOTE: It is recommended to clean your GZDoom ini from all CVAR entries of earlier releases.
-        Before using this version, search for any ini entry starting with "fullhud_",
+  NOTE: It is recommended to clean your GZDoom ini from all CVAR entries of earlier releases. 
+        Before using this version, search for any ini entry starting with "fullhud_", 
         delete all those lines, save the file, then launch the game with the new mod
   [ALL] Complete rewrite of the entire mod in ZScript, done by 3saster
   [ALL] Status bar changes are now instantaneous (leaving the menu is no longer required to see differences)
   [ALL] Split mode is now the new default (should make it easier to see if you are in fullscreen mode or not)
-  [ALL] Transparency features:
+  [ALL] Transparency features: 
            - Now has 11 settings: 0.0 (off), 0.1-0.9, 1.0 (full)
            - Option for opaque numbers and graphics (not affected by transparency settings)
   [ALL] Level stats system overhaul:
@@ -222,27 +220,27 @@ Tested With          : GZDoom
            - Stats now always aligning to each other in the same corner (dynamically adjust to the longest line)
            - Stats aligned to the bottom in split mode will now sit on top of the status bar
            - Any stat can now turn green (default) or red when reaching 100% completion (can also be disabled)
-  [ALL] Boom HUD colors: Ammo counter now takes backpack into consideration; armor value now accurately
+  [ALL] Boom HUD colors: Ammo counter now takes backpack into consideration; armor value now accurately 
                          displays protection level (should account for possible DEHACKED changes)
   [ALL] Level stats: Time display now shows hub time if available, otherwise map time
   [ALL] Credits subpage (with version number) added to menu
   [DOOM/CHEX/HACX/HERETIC] New option to choose whether to show status bar on automap or not
   [DOOM/CHEX/HACX] Split mode: Added frags counter (DM only)
-  [DOOM/CHEX/HACX] Split mode: Moved selected inventory item next to the mugshot (w/o mugshot replacement)
+  [DOOM/CHEX/HACX] Split mode: Moved selected inventory item next to the mugshot (w/o mugshot replacement) 
                                for new stats display
   [DOOM/CHEX/HACX] Selected inventory item now properly centered
   [DOOM/CHEX/HACX] Will work with some WADs based on DECORATE/ZScript (e.g. works with dead.air)
   [DOOM/CHEX/HACX] Removed "Interpolate health & armor" (useless feature)
   [CHEX/HACX/HARMONY] Removed Strife color scheme as predefined automap setting
   [CHEX] When BOOM HUD colors are on, the color of health > 100 and blue armor is now LIGHTBLUE
-  [CHEX] Berserk display option hidden. If a berserk pack is found, it will still be shown
+  [CHEX] Berserk display option hidden. If a berserk pack is found, it will still be shown 
          if CVAR fullhud_showberserk=true (can only be done from console)
   [CHEX] Non-split mode: "Frag" display added (DM only)
   [CHEX] "Kills" stats renamed to "Zorch"
   [HACX] Split mode: Colors of arms numbers are now inverted (dark=missing, bright=obtained)
   [HACX] Boom color mode now hidden from menu
   [HERETIC/HEXEN] Split mode: "Kills" display implemented differently (DM only)
-  [HERETIC] Non-split mode: Addressed issue with transparent status bar having its life chain
+  [HERETIC] Non-split mode: Addressed issue with transparent status bar having its life chain 
                             shining through the bottom of the demon heads (not fixed, but better)
   [HERETIC] Non-split mode: Status bar now properly centered
   [HERETIC] Split mode: Chain on left side centered
@@ -289,7 +287,7 @@ Tested With          : GZDoom
   [DOOM/CHEX] Split bar: ARMS numbers can now be turned off (default: on)
 
 > Version 4.7.5 (Mar 16, 2019)
-  [DOOM/CHEX] INDEXFONT for secondary ammo display replaced with SMALLFONT
+  [DOOM/CHEX] INDEXFONT for secondary ammo display replaced with SMALLFONT 
 
 > Version 4.7.4 (Mar 14, 2019)
   [DOOM/CHEX] Secondary ammo display support
@@ -321,7 +319,7 @@ Tested With          : GZDoom
   [HEXEN] Automap: Gargoyles removed
 
 > Version 4.5 (Oct 24, 2018)
-  [ALL] Menu: Can now choose between 3 degrees of transparency
+  [ALL] Menu: Can now choose between 3 degrees of transparency 
   [ALL] Transparency: Only background images are affected by transparency (mugshot, numbers and keys stay opaque)
   [HERETIC] Minor transparency tuning
   [HEXEN] Mana bars: Improved transparency
@@ -362,7 +360,7 @@ Tested With          : GZDoom
   [HERETIC/HEXEN] Inventory bar now also integrated into transparent (centered) status bar
 
 > Version 4.0 (Sep 28, 2018)
-  [INFO] Now uses "height 0" to redraw the original (non-fullscreen) status bars.
+  [INFO] Now uses "height 0" to redraw the original (non-fullscreen) status bars. 
          Normal status bars can still be used with some limitations (but still NOT recommended).
   [ALL] Option added to choose between normal and split status bars
   [ALL] Automap always uses split versions (to increase viewing area)
@@ -377,9 +375,9 @@ Tested With          : GZDoom
   [DOOM] Boom status bar colors should now work with most customized PWAD status bars
 
 > Version 3.1 (Sep 21, 2018)
-  [ALL] Added option to use Boom colors for Doom status bar numbers
+  [ALL] Added option to use Boom colors for Doom status bar numbers 
         (Note: Not available in Heretic or Hexen)
-  [ALL: TRANSPARENT] Ammo, health and armor counters are now always opaque
+  [ALL: TRANSPARENT] Ammo, health and armor counters are now always opaque 
                      (also solves problem with Boom armor counter)
   [ALL] Level stats transparency slightly reduced (from alpha 0.6 to 0.7)
   [ALL] "Show Level Stats" options renamed (from "Off"/"On" to "No"/"Yes")
@@ -397,7 +395,7 @@ Tested With          : GZDoom
   [ALL: OPAQUE] Optimized contents for opacity (needless graphics and code removed)
   [HEXEN: OPAQUE] Fix for life chain shining through status bar on the lower right side
   [DOOM/CHEX/HACX/HARMONY] Fixed potential problem with wrong fullscreenoffsets for mugshot
-  [DOOM/CHEX/HACX/HARMONY: TRANSPARENT] Transparency for ammo/health/armor counters
+  [DOOM/CHEX/HACX/HARMONY: TRANSPARENT] Transparency for ammo/health/armor counters 
                                         slightly increased (from alpha 0.8 to 0.7)
 
 > Version 2.6.1 (Sep 11, 2018)
@@ -407,13 +405,13 @@ Tested With          : GZDoom
   [HEXEN] Standard status bar now properly aligned
   [HEXEN] Mana counters moved 1px to the left to match standard status bar
   [DOOM/CHEX/HACX/HARMONY] Moved BACKGRND to game-doomchex filter folder
-  [DOOM/CHEX/HACX/HARMONY] Different drawing method for automap status bar background
+  [DOOM/CHEX/HACX/HARMONY] Different drawing method for automap status bar background 
                            (BACKGRND is now 640x32 instead of 1920x32)
 
 > Version 2.5 (Sep 7, 2018)
-  [HERETIC/HEXEN] Level stats aligned to the upper left instead of upper right corner
+  [HERETIC/HEXEN] Level stats aligned to the upper left instead of upper right corner 
                   (to avoid collision with active powerup icons)
-  [CHEX/HACX/HARMONY] Use Strife-style automap color scheme
+  [CHEX/HACX/HARMONY] Use Strife-style automap color scheme 
                       ("Automap Options" > "Allow Map Defined Colors" must be set to "Yes")
   [DOOM/CHEX/HACX/HARMONY] Minor (invisible) optimization of how automap status bar is
                            created (BACKGRND and STBAR merged in TEXTURES.DOOM)
@@ -432,7 +430,7 @@ Tested With          : GZDoom
   [ALL] Level stats no longer use abbreviations; gapfiller zeroes removed
 
 > Version 2.2 (May 10, 2017)
-  [DOOM/CHEX/HACX/HARMONY] Black background fix for automap status bar now supports
+  [DOOM/CHEX/HACX/HARMONY] Black background fix for automap status bar now supports 
                            up to 1920px screen width when scaled to 1
   [HEXEN] More status bar alignment adjustments
 

--- a/readme.txt
+++ b/readme.txt
@@ -13,8 +13,8 @@ Other files by author: Blinking Eyes for Doom Mugshot
                        Widescreen HUDs for Doom/Doom II PWADs
 
 Description          : Fullscreen versions for the status bars of Doom-based
-                       games (Doom, Doom II, Final Doom, Freedoom, Chex, HacX, 
-                       Harmony), Heretic and Hexen with optional transparency 
+                       games (Doom, Doom II, Final Doom, Freedoom, Chex, HacX,
+                       Harmony), Heretic and Hexen with optional transparency
                        and level stats display
 
 Additional Info      : 1) Only works with GZDoom 4.3.0+, LZDoom 3.84+ and other
@@ -44,11 +44,11 @@ Additional Info      : 1) Only works with GZDoom 4.3.0+, LZDoom 3.84+ and other
                                   + Choose between 22 different stat completion colors
                                   + Optionally show countdowns for active powerups
 				  + Optionally abbreviate stats names (K/I/S)
-                       5) Adds 15-17 CVARS to your GZDoom ini, starting with "fullhud_" 
+                       5) Adds 15-17 CVARS to your GZDoom ini, starting with "fullhud_"
 
-Known issues         : [CHEX] Logo replacement will only look good if default STBAR graphics 
+Known issues         : [CHEX] Logo replacement will only look good if default STBAR graphics
                               are used (with blue background)
-                       
+
 
 Additional Credits to: id Software .................. Original Doom GFX
                        Raven Software ............... Original Heretic/Hexen GFX
@@ -62,6 +62,7 @@ Additional Credits to: id Software .................. Original Doom GFX
                        Nash Muhandes ................ Widescreen Heretic/Hexen status bars
                                                       Menu tooltips
                        Delfino Furioso .............. Hexen compatibility code patches
+                       scar45 ....................... Stats adjacent to non-split status bar
 
 ===========================================================================
 * What is included *
@@ -101,6 +102,7 @@ Tested With          : GZDoom
 * CHANGELOG *
 
 > Version 5.1.12 (xx xx, 2022)
+  [ALL] Stats: Added option for placing adjacent to (non-split) Status Bar (code by scar45)
   [HEXEN] Compatibility with "Hexen Rebalanced" and "Tempered Arms" (code by Delfino Furioso)
 
 > Version 5.1.11 (Jun 7, 2022)
@@ -145,7 +147,7 @@ Tested With          : GZDoom
   [ALL] Stats: Can now choose between 25 (before: 3) different stat completion colors
 
 > Version 5.1.4 (Jan 7, 2020)
-  NOTE: Now requires GZDoom 4.3.0+ or LZDoom 3.84+. This is due to a major internal restructure that makes 
+  NOTE: Now requires GZDoom 4.3.0+ or LZDoom 3.84+. This is due to a major internal restructure that makes
         many parts of the code (especially stats) MUCH easier to maintain, using mixins
   [ALL] General Settings: "Force HUD override" option removed. This was rather hacky and caused crashes, even when turned off
   [ALL] Added tooltips to menu options
@@ -161,7 +163,7 @@ Tested With          : GZDoom
   NOTE: Now requires GZDoom 4.2.4+. This prevents a segfault that can occur with "Force HUD override" active.
         It is recommended to avoid activating this option in LZDoom (at least for now)
   [ALL] MENUDEF: Reorganization into submenus ("General Settings", "Optional Settings", "Stats")
-  [ALL] General Settings: "Force HUD override" option added. This will override any other custom HUD and 
+  [ALL] General Settings: "Force HUD override" option added. This will override any other custom HUD and
                           use this HUD instead, regardless of load order (intended for autoload in particular)
   [ALL] Stats: "Powerup timers" option added. Works exactly the same as in Tekish's LevelInfo v1.22 (for now)
   [ALL] Stats: Fixed top-right stats not moving correctly when the vid_fps CVAR is on
@@ -170,7 +172,7 @@ Tested With          : GZDoom
   [DOOM] Automatic compatibility added for Pirate Doom
   [CHEX] Berserk mode indicator CVAR from Doom no longer saved to ini
   [HACX] No longer uses modified STBAR lump, but instead adds a small black patch to cover mugshot background
-  
+
 > Version 5.1.2 (Nov 4, 2019)
   [ALL] MENUDEF: Code optimization (now only HacX needs two files, all other games just one)
   [DOOM] Automatic compatibility added for Sunlust
@@ -184,7 +186,7 @@ Tested With          : GZDoom
 
 > Version 5.1.0 (Oct 2, 2019)
   [DOOM] Automatic compatibility with selected PWADs which needed separate fixes before. Currently included:
-         Alien Vendetta, Avactor, Back to Saturn X Ep.1+2, Doom 4 Vanilla, Doom Neural Upscale 2X, Epic 2, 
+         Alien Vendetta, Avactor, Back to Saturn X Ep.1+2, Doom 4 Vanilla, Doom Neural Upscale 2X, Epic 2,
          Eviternity and Memento Mori 2
   [DOOM/CHEX/HACX/HARMONY] Inventory: Amount is now properly right-justified and moved to the correct spot
 
@@ -204,13 +206,13 @@ Tested With          : GZDoom
   [ALL] Level stats: Added option to change stats font. 5 choices available (default: font from 4.x releases)
 
 > Version 5.0 (Sep 4, 2019)
-  NOTE: It is recommended to clean your GZDoom ini from all CVAR entries of earlier releases. 
-        Before using this version, search for any ini entry starting with "fullhud_", 
+  NOTE: It is recommended to clean your GZDoom ini from all CVAR entries of earlier releases.
+        Before using this version, search for any ini entry starting with "fullhud_",
         delete all those lines, save the file, then launch the game with the new mod
   [ALL] Complete rewrite of the entire mod in ZScript, done by 3saster
   [ALL] Status bar changes are now instantaneous (leaving the menu is no longer required to see differences)
   [ALL] Split mode is now the new default (should make it easier to see if you are in fullscreen mode or not)
-  [ALL] Transparency features: 
+  [ALL] Transparency features:
            - Now has 11 settings: 0.0 (off), 0.1-0.9, 1.0 (full)
            - Option for opaque numbers and graphics (not affected by transparency settings)
   [ALL] Level stats system overhaul:
@@ -220,27 +222,27 @@ Tested With          : GZDoom
            - Stats now always aligning to each other in the same corner (dynamically adjust to the longest line)
            - Stats aligned to the bottom in split mode will now sit on top of the status bar
            - Any stat can now turn green (default) or red when reaching 100% completion (can also be disabled)
-  [ALL] Boom HUD colors: Ammo counter now takes backpack into consideration; armor value now accurately 
+  [ALL] Boom HUD colors: Ammo counter now takes backpack into consideration; armor value now accurately
                          displays protection level (should account for possible DEHACKED changes)
   [ALL] Level stats: Time display now shows hub time if available, otherwise map time
   [ALL] Credits subpage (with version number) added to menu
   [DOOM/CHEX/HACX/HERETIC] New option to choose whether to show status bar on automap or not
   [DOOM/CHEX/HACX] Split mode: Added frags counter (DM only)
-  [DOOM/CHEX/HACX] Split mode: Moved selected inventory item next to the mugshot (w/o mugshot replacement) 
+  [DOOM/CHEX/HACX] Split mode: Moved selected inventory item next to the mugshot (w/o mugshot replacement)
                                for new stats display
   [DOOM/CHEX/HACX] Selected inventory item now properly centered
   [DOOM/CHEX/HACX] Will work with some WADs based on DECORATE/ZScript (e.g. works with dead.air)
   [DOOM/CHEX/HACX] Removed "Interpolate health & armor" (useless feature)
   [CHEX/HACX/HARMONY] Removed Strife color scheme as predefined automap setting
   [CHEX] When BOOM HUD colors are on, the color of health > 100 and blue armor is now LIGHTBLUE
-  [CHEX] Berserk display option hidden. If a berserk pack is found, it will still be shown 
+  [CHEX] Berserk display option hidden. If a berserk pack is found, it will still be shown
          if CVAR fullhud_showberserk=true (can only be done from console)
   [CHEX] Non-split mode: "Frag" display added (DM only)
   [CHEX] "Kills" stats renamed to "Zorch"
   [HACX] Split mode: Colors of arms numbers are now inverted (dark=missing, bright=obtained)
   [HACX] Boom color mode now hidden from menu
   [HERETIC/HEXEN] Split mode: "Kills" display implemented differently (DM only)
-  [HERETIC] Non-split mode: Addressed issue with transparent status bar having its life chain 
+  [HERETIC] Non-split mode: Addressed issue with transparent status bar having its life chain
                             shining through the bottom of the demon heads (not fixed, but better)
   [HERETIC] Non-split mode: Status bar now properly centered
   [HERETIC] Split mode: Chain on left side centered
@@ -287,7 +289,7 @@ Tested With          : GZDoom
   [DOOM/CHEX] Split bar: ARMS numbers can now be turned off (default: on)
 
 > Version 4.7.5 (Mar 16, 2019)
-  [DOOM/CHEX] INDEXFONT for secondary ammo display replaced with SMALLFONT 
+  [DOOM/CHEX] INDEXFONT for secondary ammo display replaced with SMALLFONT
 
 > Version 4.7.4 (Mar 14, 2019)
   [DOOM/CHEX] Secondary ammo display support
@@ -319,7 +321,7 @@ Tested With          : GZDoom
   [HEXEN] Automap: Gargoyles removed
 
 > Version 4.5 (Oct 24, 2018)
-  [ALL] Menu: Can now choose between 3 degrees of transparency 
+  [ALL] Menu: Can now choose between 3 degrees of transparency
   [ALL] Transparency: Only background images are affected by transparency (mugshot, numbers and keys stay opaque)
   [HERETIC] Minor transparency tuning
   [HEXEN] Mana bars: Improved transparency
@@ -360,7 +362,7 @@ Tested With          : GZDoom
   [HERETIC/HEXEN] Inventory bar now also integrated into transparent (centered) status bar
 
 > Version 4.0 (Sep 28, 2018)
-  [INFO] Now uses "height 0" to redraw the original (non-fullscreen) status bars. 
+  [INFO] Now uses "height 0" to redraw the original (non-fullscreen) status bars.
          Normal status bars can still be used with some limitations (but still NOT recommended).
   [ALL] Option added to choose between normal and split status bars
   [ALL] Automap always uses split versions (to increase viewing area)
@@ -375,9 +377,9 @@ Tested With          : GZDoom
   [DOOM] Boom status bar colors should now work with most customized PWAD status bars
 
 > Version 3.1 (Sep 21, 2018)
-  [ALL] Added option to use Boom colors for Doom status bar numbers 
+  [ALL] Added option to use Boom colors for Doom status bar numbers
         (Note: Not available in Heretic or Hexen)
-  [ALL: TRANSPARENT] Ammo, health and armor counters are now always opaque 
+  [ALL: TRANSPARENT] Ammo, health and armor counters are now always opaque
                      (also solves problem with Boom armor counter)
   [ALL] Level stats transparency slightly reduced (from alpha 0.6 to 0.7)
   [ALL] "Show Level Stats" options renamed (from "Off"/"On" to "No"/"Yes")
@@ -395,7 +397,7 @@ Tested With          : GZDoom
   [ALL: OPAQUE] Optimized contents for opacity (needless graphics and code removed)
   [HEXEN: OPAQUE] Fix for life chain shining through status bar on the lower right side
   [DOOM/CHEX/HACX/HARMONY] Fixed potential problem with wrong fullscreenoffsets for mugshot
-  [DOOM/CHEX/HACX/HARMONY: TRANSPARENT] Transparency for ammo/health/armor counters 
+  [DOOM/CHEX/HACX/HARMONY: TRANSPARENT] Transparency for ammo/health/armor counters
                                         slightly increased (from alpha 0.8 to 0.7)
 
 > Version 2.6.1 (Sep 11, 2018)
@@ -405,13 +407,13 @@ Tested With          : GZDoom
   [HEXEN] Standard status bar now properly aligned
   [HEXEN] Mana counters moved 1px to the left to match standard status bar
   [DOOM/CHEX/HACX/HARMONY] Moved BACKGRND to game-doomchex filter folder
-  [DOOM/CHEX/HACX/HARMONY] Different drawing method for automap status bar background 
+  [DOOM/CHEX/HACX/HARMONY] Different drawing method for automap status bar background
                            (BACKGRND is now 640x32 instead of 1920x32)
 
 > Version 2.5 (Sep 7, 2018)
-  [HERETIC/HEXEN] Level stats aligned to the upper left instead of upper right corner 
+  [HERETIC/HEXEN] Level stats aligned to the upper left instead of upper right corner
                   (to avoid collision with active powerup icons)
-  [CHEX/HACX/HARMONY] Use Strife-style automap color scheme 
+  [CHEX/HACX/HARMONY] Use Strife-style automap color scheme
                       ("Automap Options" > "Allow Map Defined Colors" must be set to "Yes")
   [DOOM/CHEX/HACX/HARMONY] Minor (invisible) optimization of how automap status bar is
                            created (BACKGRND and STBAR merged in TEXTURES.DOOM)
@@ -430,7 +432,7 @@ Tested With          : GZDoom
   [ALL] Level stats no longer use abbreviations; gapfiller zeroes removed
 
 > Version 2.2 (May 10, 2017)
-  [DOOM/CHEX/HACX/HARMONY] Black background fix for automap status bar now supports 
+  [DOOM/CHEX/HACX/HARMONY] Black background fix for automap status bar now supports
                            up to 1920px screen width when scaled to 1
   [HEXEN] More status bar alignment adjustments
 

--- a/readme.txt
+++ b/readme.txt
@@ -13,8 +13,8 @@ Other files by author: Blinking Eyes for Doom Mugshot
                        Widescreen HUDs for Doom/Doom II PWADs
 
 Description          : Fullscreen versions for the status bars of Doom-based
-                       games (Doom, Doom II, Final Doom, Freedoom, Chex, HacX, 
-                       Harmony), Heretic and Hexen with optional transparency 
+                       games (Doom, Doom II, Final Doom, Freedoom, Chex, HacX,
+                       Harmony), Heretic and Hexen with optional transparency
                        and level stats display
 
 Additional Info      : 1) Only works with GZDoom 4.3.0+, LZDoom 3.84+ and other
@@ -38,17 +38,21 @@ Additional Info      : 1) Only works with GZDoom 4.3.0+, LZDoom 3.84+ and other
                              - Switch between Armor Class and armor points (Hexen)
                              - Level stats fully customizable:
                                   + Display in %, countdowns or fraction (+ time)
-                                  + 6 positions (top left/right, center left/right, bottom left/right)
+                                  + 8 positions:
+                                      - top left/right
+                                      - center left/right
+                                      - bottom left/right
+                                      - status bar left/right
                                   + Toggle any stat (kills, secrets, items, time)
                                   + Choose between 4 different fonts
                                   + Choose between 22 different stat completion colors
                                   + Optionally show countdowns for active powerups
 				  + Optionally abbreviate stats names (K/I/S)
-                       5) Adds 15-17 CVARS to your GZDoom ini, starting with "fullhud_" 
+                       5) Adds 15-17 CVARS to your GZDoom ini, starting with "fullhud_"
 
-Known issues         : [CHEX] Logo replacement will only look good if default STBAR graphics 
+Known issues         : [CHEX] Logo replacement will only look good if default STBAR graphics
                               are used (with blue background)
-                       
+
 
 Additional Credits to: id Software .................. Original Doom GFX
                        Raven Software ............... Original Heretic/Hexen GFX
@@ -62,6 +66,7 @@ Additional Credits to: id Software .................. Original Doom GFX
                        Nash Muhandes ................ Widescreen Heretic/Hexen status bars
                                                       Menu tooltips
                        Delfino Furioso .............. Hexen compatibility code patches
+                       scar45 ....................... Stats positioned next to status bar
 
 ===========================================================================
 * What is included *
@@ -101,6 +106,7 @@ Tested With          : GZDoom
 * CHANGELOG *
 
 > Version 5.1.12 (xx xx, 2022)
+  [ALL] Stats: Added option to position next to statusbar (code by scar45)
   [HEXEN] Compatibility with "Hexen Rebalanced" and "Tempered Arms" (code by Delfino Furioso)
 
 > Version 5.1.11 (Jun 7, 2022)
@@ -145,7 +151,7 @@ Tested With          : GZDoom
   [ALL] Stats: Can now choose between 25 (before: 3) different stat completion colors
 
 > Version 5.1.4 (Jan 7, 2020)
-  NOTE: Now requires GZDoom 4.3.0+ or LZDoom 3.84+. This is due to a major internal restructure that makes 
+  NOTE: Now requires GZDoom 4.3.0+ or LZDoom 3.84+. This is due to a major internal restructure that makes
         many parts of the code (especially stats) MUCH easier to maintain, using mixins
   [ALL] General Settings: "Force HUD override" option removed. This was rather hacky and caused crashes, even when turned off
   [ALL] Added tooltips to menu options
@@ -161,7 +167,7 @@ Tested With          : GZDoom
   NOTE: Now requires GZDoom 4.2.4+. This prevents a segfault that can occur with "Force HUD override" active.
         It is recommended to avoid activating this option in LZDoom (at least for now)
   [ALL] MENUDEF: Reorganization into submenus ("General Settings", "Optional Settings", "Stats")
-  [ALL] General Settings: "Force HUD override" option added. This will override any other custom HUD and 
+  [ALL] General Settings: "Force HUD override" option added. This will override any other custom HUD and
                           use this HUD instead, regardless of load order (intended for autoload in particular)
   [ALL] Stats: "Powerup timers" option added. Works exactly the same as in Tekish's LevelInfo v1.22 (for now)
   [ALL] Stats: Fixed top-right stats not moving correctly when the vid_fps CVAR is on
@@ -170,7 +176,7 @@ Tested With          : GZDoom
   [DOOM] Automatic compatibility added for Pirate Doom
   [CHEX] Berserk mode indicator CVAR from Doom no longer saved to ini
   [HACX] No longer uses modified STBAR lump, but instead adds a small black patch to cover mugshot background
-  
+
 > Version 5.1.2 (Nov 4, 2019)
   [ALL] MENUDEF: Code optimization (now only HacX needs two files, all other games just one)
   [DOOM] Automatic compatibility added for Sunlust
@@ -184,7 +190,7 @@ Tested With          : GZDoom
 
 > Version 5.1.0 (Oct 2, 2019)
   [DOOM] Automatic compatibility with selected PWADs which needed separate fixes before. Currently included:
-         Alien Vendetta, Avactor, Back to Saturn X Ep.1+2, Doom 4 Vanilla, Doom Neural Upscale 2X, Epic 2, 
+         Alien Vendetta, Avactor, Back to Saturn X Ep.1+2, Doom 4 Vanilla, Doom Neural Upscale 2X, Epic 2,
          Eviternity and Memento Mori 2
   [DOOM/CHEX/HACX/HARMONY] Inventory: Amount is now properly right-justified and moved to the correct spot
 
@@ -204,13 +210,13 @@ Tested With          : GZDoom
   [ALL] Level stats: Added option to change stats font. 5 choices available (default: font from 4.x releases)
 
 > Version 5.0 (Sep 4, 2019)
-  NOTE: It is recommended to clean your GZDoom ini from all CVAR entries of earlier releases. 
-        Before using this version, search for any ini entry starting with "fullhud_", 
+  NOTE: It is recommended to clean your GZDoom ini from all CVAR entries of earlier releases.
+        Before using this version, search for any ini entry starting with "fullhud_",
         delete all those lines, save the file, then launch the game with the new mod
   [ALL] Complete rewrite of the entire mod in ZScript, done by 3saster
   [ALL] Status bar changes are now instantaneous (leaving the menu is no longer required to see differences)
   [ALL] Split mode is now the new default (should make it easier to see if you are in fullscreen mode or not)
-  [ALL] Transparency features: 
+  [ALL] Transparency features:
            - Now has 11 settings: 0.0 (off), 0.1-0.9, 1.0 (full)
            - Option for opaque numbers and graphics (not affected by transparency settings)
   [ALL] Level stats system overhaul:
@@ -220,27 +226,27 @@ Tested With          : GZDoom
            - Stats now always aligning to each other in the same corner (dynamically adjust to the longest line)
            - Stats aligned to the bottom in split mode will now sit on top of the status bar
            - Any stat can now turn green (default) or red when reaching 100% completion (can also be disabled)
-  [ALL] Boom HUD colors: Ammo counter now takes backpack into consideration; armor value now accurately 
+  [ALL] Boom HUD colors: Ammo counter now takes backpack into consideration; armor value now accurately
                          displays protection level (should account for possible DEHACKED changes)
   [ALL] Level stats: Time display now shows hub time if available, otherwise map time
   [ALL] Credits subpage (with version number) added to menu
   [DOOM/CHEX/HACX/HERETIC] New option to choose whether to show status bar on automap or not
   [DOOM/CHEX/HACX] Split mode: Added frags counter (DM only)
-  [DOOM/CHEX/HACX] Split mode: Moved selected inventory item next to the mugshot (w/o mugshot replacement) 
+  [DOOM/CHEX/HACX] Split mode: Moved selected inventory item next to the mugshot (w/o mugshot replacement)
                                for new stats display
   [DOOM/CHEX/HACX] Selected inventory item now properly centered
   [DOOM/CHEX/HACX] Will work with some WADs based on DECORATE/ZScript (e.g. works with dead.air)
   [DOOM/CHEX/HACX] Removed "Interpolate health & armor" (useless feature)
   [CHEX/HACX/HARMONY] Removed Strife color scheme as predefined automap setting
   [CHEX] When BOOM HUD colors are on, the color of health > 100 and blue armor is now LIGHTBLUE
-  [CHEX] Berserk display option hidden. If a berserk pack is found, it will still be shown 
+  [CHEX] Berserk display option hidden. If a berserk pack is found, it will still be shown
          if CVAR fullhud_showberserk=true (can only be done from console)
   [CHEX] Non-split mode: "Frag" display added (DM only)
   [CHEX] "Kills" stats renamed to "Zorch"
   [HACX] Split mode: Colors of arms numbers are now inverted (dark=missing, bright=obtained)
   [HACX] Boom color mode now hidden from menu
   [HERETIC/HEXEN] Split mode: "Kills" display implemented differently (DM only)
-  [HERETIC] Non-split mode: Addressed issue with transparent status bar having its life chain 
+  [HERETIC] Non-split mode: Addressed issue with transparent status bar having its life chain
                             shining through the bottom of the demon heads (not fixed, but better)
   [HERETIC] Non-split mode: Status bar now properly centered
   [HERETIC] Split mode: Chain on left side centered
@@ -287,7 +293,7 @@ Tested With          : GZDoom
   [DOOM/CHEX] Split bar: ARMS numbers can now be turned off (default: on)
 
 > Version 4.7.5 (Mar 16, 2019)
-  [DOOM/CHEX] INDEXFONT for secondary ammo display replaced with SMALLFONT 
+  [DOOM/CHEX] INDEXFONT for secondary ammo display replaced with SMALLFONT
 
 > Version 4.7.4 (Mar 14, 2019)
   [DOOM/CHEX] Secondary ammo display support
@@ -319,7 +325,7 @@ Tested With          : GZDoom
   [HEXEN] Automap: Gargoyles removed
 
 > Version 4.5 (Oct 24, 2018)
-  [ALL] Menu: Can now choose between 3 degrees of transparency 
+  [ALL] Menu: Can now choose between 3 degrees of transparency
   [ALL] Transparency: Only background images are affected by transparency (mugshot, numbers and keys stay opaque)
   [HERETIC] Minor transparency tuning
   [HEXEN] Mana bars: Improved transparency
@@ -360,7 +366,7 @@ Tested With          : GZDoom
   [HERETIC/HEXEN] Inventory bar now also integrated into transparent (centered) status bar
 
 > Version 4.0 (Sep 28, 2018)
-  [INFO] Now uses "height 0" to redraw the original (non-fullscreen) status bars. 
+  [INFO] Now uses "height 0" to redraw the original (non-fullscreen) status bars.
          Normal status bars can still be used with some limitations (but still NOT recommended).
   [ALL] Option added to choose between normal and split status bars
   [ALL] Automap always uses split versions (to increase viewing area)
@@ -375,9 +381,9 @@ Tested With          : GZDoom
   [DOOM] Boom status bar colors should now work with most customized PWAD status bars
 
 > Version 3.1 (Sep 21, 2018)
-  [ALL] Added option to use Boom colors for Doom status bar numbers 
+  [ALL] Added option to use Boom colors for Doom status bar numbers
         (Note: Not available in Heretic or Hexen)
-  [ALL: TRANSPARENT] Ammo, health and armor counters are now always opaque 
+  [ALL: TRANSPARENT] Ammo, health and armor counters are now always opaque
                      (also solves problem with Boom armor counter)
   [ALL] Level stats transparency slightly reduced (from alpha 0.6 to 0.7)
   [ALL] "Show Level Stats" options renamed (from "Off"/"On" to "No"/"Yes")
@@ -395,7 +401,7 @@ Tested With          : GZDoom
   [ALL: OPAQUE] Optimized contents for opacity (needless graphics and code removed)
   [HEXEN: OPAQUE] Fix for life chain shining through status bar on the lower right side
   [DOOM/CHEX/HACX/HARMONY] Fixed potential problem with wrong fullscreenoffsets for mugshot
-  [DOOM/CHEX/HACX/HARMONY: TRANSPARENT] Transparency for ammo/health/armor counters 
+  [DOOM/CHEX/HACX/HARMONY: TRANSPARENT] Transparency for ammo/health/armor counters
                                         slightly increased (from alpha 0.8 to 0.7)
 
 > Version 2.6.1 (Sep 11, 2018)
@@ -405,13 +411,13 @@ Tested With          : GZDoom
   [HEXEN] Standard status bar now properly aligned
   [HEXEN] Mana counters moved 1px to the left to match standard status bar
   [DOOM/CHEX/HACX/HARMONY] Moved BACKGRND to game-doomchex filter folder
-  [DOOM/CHEX/HACX/HARMONY] Different drawing method for automap status bar background 
+  [DOOM/CHEX/HACX/HARMONY] Different drawing method for automap status bar background
                            (BACKGRND is now 640x32 instead of 1920x32)
 
 > Version 2.5 (Sep 7, 2018)
-  [HERETIC/HEXEN] Level stats aligned to the upper left instead of upper right corner 
+  [HERETIC/HEXEN] Level stats aligned to the upper left instead of upper right corner
                   (to avoid collision with active powerup icons)
-  [CHEX/HACX/HARMONY] Use Strife-style automap color scheme 
+  [CHEX/HACX/HARMONY] Use Strife-style automap color scheme
                       ("Automap Options" > "Allow Map Defined Colors" must be set to "Yes")
   [DOOM/CHEX/HACX/HARMONY] Minor (invisible) optimization of how automap status bar is
                            created (BACKGRND and STBAR merged in TEXTURES.DOOM)
@@ -430,7 +436,7 @@ Tested With          : GZDoom
   [ALL] Level stats no longer use abbreviations; gapfiller zeroes removed
 
 > Version 2.2 (May 10, 2017)
-  [DOOM/CHEX/HACX/HARMONY] Black background fix for automap status bar now supports 
+  [DOOM/CHEX/HACX/HARMONY] Black background fix for automap status bar now supports
                            up to 1920px screen width when scaled to 1
   [HEXEN] More status bar alignment adjustments
 

--- a/zscript/stats/stats.zs
+++ b/zscript/stats/stats.zs
@@ -7,7 +7,7 @@ mixin Class Stats
 		COUNTDOWN = 2,
 		FRACTION = 3
 	}
-	
+
 	enum StatsColorValues
 	{
 		NONE = 0,
@@ -21,19 +21,19 @@ mixin Class Stats
 		CYAN = 8,
 		FIRE = 9,
 		GOLD = 10,
-		DARKGRAY = 11, 
+		DARKGRAY = 11,
 		GREEN = 12,
-		DARKGREEN = 13, 
+		DARKGREEN = 13,
 		OLIVE = 14,
 		ORANGE = 15,
 		PURPLE = 16,
 		RED = 17,
-		DARKRED = 18, 
+		DARKRED = 18,
 		SAPPHIRE = 19,
 		TEAL = 20,
 		YELLOW = 21
 	}
-	
+
 	enum StatsPosition
 	{
 		OFF = 0,
@@ -134,27 +134,27 @@ mixin Class Stats
 	void DrawStatLine(statFont sfnt, int cr, Vector2 pos, String text, double alpha)
 	{
 		Vector2 scale = GetHUDScale();
-		
+
 		// These values are jury-rigged; they were initially designed for my personal settings before becoming generic
 		int VirtualWidth  = int(sfnt.scale.x * 6.0/scale.x * Screen.GetWidth() /2560);
 		int VirtualHeight = int(sfnt.scale.y * 7.2/scale.y * Screen.GetHeight()/1440);
-		
+
 		int posX = int( pos.x >= 0 ? pos.x : VirtualWidth  + pos.x );
 		int posY = int( pos.y >= 0 ? pos.y : VirtualHeight + pos.y );
 
-		screen.DrawText(sfnt.fnt, cr, posX, posY, text, 
+		screen.DrawText(sfnt.fnt, cr, posX, posY, text,
 			DTA_KeepRatio, true,
 			DTA_VirtualWidth, VirtualWidth, DTA_VirtualHeight, VirtualHeight, DTA_Alpha, alpha);
 	}
-	
+
 	protected virtual void DrawLevelStats (statFont sfnt, int state = HUD_StatusBar)
 	{
 		int alphaO = alphaOpaque.GetInt();
 		double alphaFloat = alphaO == OP_NUM || alphaO == OP_NUMGRAPH ? 1 : 1-alphaValue.getfloat();
-		
+
 		let fnt = sfnt.fnt;
 		int padding = sfnt.padding;
-		
+
 		int compColor;
 		switch(statsCompColor.GetInt())
 		{
@@ -226,7 +226,7 @@ mixin Class Stats
 				compColor = Font.CR_YELLOW;
 				break;
 		}
-		
+
 		string kills = "";
 		string secrets = "";
 		string items = "";
@@ -235,18 +235,18 @@ mixin Class Stats
 		int mkilled   = multiplayer? CPlayer.killcount   : Level.killed_monsters;
 		int sfound    = multiplayer? CPlayer.secretcount : Level.found_secrets;
 		int ifound    = multiplayer? CPlayer.itemcount   : Level.found_items;
-		
+
 		// Format based on type specified
 		bool killComp = false;
 		bool secretComp = false;
 		bool itemComp = false;
-		string killstring    = (gameinfo.gametype & GAME_Chex) ? 
-		                       Stringtable.Localize("$FULLHUD_KILLS_CHEX") : 
+		string killstring    = (gameinfo.gametype & GAME_Chex) ?
+		                       Stringtable.Localize("$FULLHUD_KILLS_CHEX") :
 				       Stringtable.Localize("$FULLHUD_KILLS");
 		string secretstring  = Stringtable.Localize("$FULLHUD_SECRETS");
 		string itemstring    = Stringtable.Localize("$FULLHUD_ITEMS");
-		string killstring2   = (gameinfo.gametype & GAME_Chex) ? 
-		                       Stringtable.Localize("$FULLHUD_KILLS_CHEX_SHORT") : 
+		string killstring2   = (gameinfo.gametype & GAME_Chex) ?
+		                       Stringtable.Localize("$FULLHUD_KILLS_CHEX_SHORT") :
 				       Stringtable.Localize("$FULLHUD_KILLS_SHORT");
 		string secretstring2 = Stringtable.Localize("$FULLHUD_SECRETS_SHORT");
 		string itemstring2   = Stringtable.Localize("$FULLHUD_ITEMS_SHORT");
@@ -269,7 +269,7 @@ mixin Class Stats
 				if (siSecretsP.GetValue() == 100) secretComp = true;
 				if (siItemsP.GetValue()   == 100) itemComp = true;
 				break;
-				
+
 			case COUNTDOWN:
 				string space = string.format(string.format("%%%ds",padding), padding ? "" : " ");
 				string leftstring = Stringtable.Localize("$FULLHUD_LEFT_STRING");
@@ -281,7 +281,7 @@ mixin Class Stats
 				if (siSecretsC.GetValue() == 0) secretComp = true;
 				if (siItemsC.GetValue()   == 0) itemComp = true;
 				break;
-				
+
 			case FRACTION:
 				if (statKills.GetInt())   kills   = string.format("%s: %i/%i", killstring,   siKillsF.GetValue(),   Level.total_monsters);
 				if (statSecrets.GetInt()) secrets = string.format("%s: %i/%i", secretstring, siSecretsF.GetValue(), Level.total_secrets);
@@ -295,7 +295,7 @@ mixin Class Stats
 		// Format Level time
 		int hubtime = Level.time/Thinker.TICRATE;
 		if (statTime.GetInt()) time = string.format("%02d:%02d:%02d",hubtime/3600,(hubtime/60)%60,hubtime%60);
-		
+
 		// Format Powerups
 		Array<String> PowerupStrings;
 		int powerlength = 0;
@@ -321,31 +321,34 @@ mixin Class Stats
 			powerlength = max(powerlength, fnt.StringWidth(morphString));
 		}
 
-		int textSize = fnt.GetHeight() + sfnt.vspace;
+		int textSize  = fnt.GetHeight() + sfnt.vspace;
 		int killpos   = statsType.GetInt() ? statKills.getInt()    : OFF;
 		int secretpos = statsType.GetInt() ? statSecrets.getInt()  : OFF;
 		int itempos   = statsType.GetInt() ? statItems.getInt()    : OFF;
 		int timepos   = statsType.GetInt() ? statTime.getInt()     : OFF;
 		int powerpos  = statsType.GetInt() ? statPowerups.getInt() : OFF;
-		
+		int cozypos   = statsType.GetInt() ? statsCozy.getInt()    : OFF;
+
 		// Make each block have the same length
 		int maxlength[7] = {0,0,0,0,0,0,0};
 		maxlength[killpos]   = max(maxlength[killpos],  fnt.StringWidth(kills));
 		maxlength[secretpos] = max(maxlength[secretpos],fnt.StringWidth(secrets));
 		maxlength[itempos]   = max(maxlength[itempos],  fnt.StringWidth(items));
 		maxlength[powerpos]  = max(maxlength[powerpos], powerlength);
-		
+
 		kills =   makeLength(kills,  fnt, maxlength[killpos]   + padding);
 		secrets = makeLength(secrets,fnt, maxlength[secretpos] + padding);
 		items =   makeLength(items,  fnt, maxlength[itempos]   + padding);
 		for(int i = 0; i < PowerupStrings.size(); i++)
 			PowerupStrings[i] = makeLength(PowerupStrings[i],  fnt, maxlength[powerpos] + padding, ": ");
 		morphString = makeLength(morphString, fnt, maxlength[powerpos] + padding, ": ");
-		
+
 		int sPush = sfnt.sPush;
 		int tHeight = sfnt.tHeight;
 		Vector2 scale = GetHUDScale();
+		int VirtualWidth  = int(sfnt.scale.x * 6.0/scale.x * Screen.GetWidth() /2560);
 		int VirtualHeight = int(sfnt.scale.y * 7.2/scale.y * Screen.GetHeight()/1440);
+
 		// Top Left
 		int topLeftTotal = 0;
 		if(killpos   == TOPLEFT) DrawStatLine(sfnt, killComp   ? compColor : Font.CR_WHITE, (sPush,tHeight+textSize*topLeftTotal++) ,kills,alphaFloat);
@@ -353,9 +356,10 @@ mixin Class Stats
 		if(itempos   == TOPLEFT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (sPush,tHeight+textSize*topLeftTotal++) ,items,alphaFloat);
 		if(timepos   == TOPLEFT) DrawStatLine(sfnt,                          Font.CR_WHITE, (sPush,tHeight+textSize*topLeftTotal++) ,time,alphaFloat);
 		if(powerpos  == TOPLEFT)
-			for(int i = 0; i < PowerupStrings.size(); i++)	
+			for(int i = 0; i < PowerupStrings.size(); i++)
 				DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
 				(sPush,tHeight+textSize*topLeftTotal++), PowerupStrings[i],alphaFloat);
+
 		// Top Right
 		// This needs special handling for vid_fps
 		int conOffset = vid_fps ? GetConSize() * VirtualHeight/Screen.GetHeight() : 0;
@@ -365,9 +369,10 @@ mixin Class Stats
 		if(itempos   == TOPRIGHT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (-sPush-fnt.StringWidth(items),  conOffset+tHeight+textSize*topRightTotal++)  ,items,alphaFloat);
 		if(timepos   == TOPRIGHT) DrawStatLine(sfnt,                          Font.CR_WHITE, (-sPush-fnt.StringWidth(time),   conOffset+tHeight+textSize*topRightTotal++)   ,time,alphaFloat);
 		if(powerpos  == TOPRIGHT)
-			for(int i = 0; i < PowerupStrings.size(); i++)	
+			for(int i = 0; i < PowerupStrings.size(); i++)
 				DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
 				(-sPush-fnt.StringWidth(PowerupStrings[i]),conOffset+tHeight+textSize*topRightTotal++), PowerupStrings[i],alphaFloat);
+
 		// Center Left
 		int clTotal = 0;
 		if(itempos   == CENTERLEFT) clTotal++;
@@ -382,9 +387,10 @@ mixin Class Stats
 		if(itempos   == CENTERLEFT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (sPush,clHeight+textSize*centerLeftTotal++) ,items,alphaFloat);
 		if(timepos   == CENTERLEFT) DrawStatLine(sfnt,                          Font.CR_WHITE, (sPush,clHeight+textSize*centerLeftTotal++) ,time,alphaFloat);
 		if(powerpos  == CENTERLEFT)
-			for(int i = 0; i < PowerupStrings.size(); i++)	
+			for(int i = 0; i < PowerupStrings.size(); i++)
 				DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
 				(sPush,clHeight+textSize*centerLeftTotal++), PowerupStrings[i],alphaFloat);
+
 		// Center Right
 		int crTotal = 0;
 		if(itempos   == CENTERRIGHT) crTotal++;
@@ -399,34 +405,114 @@ mixin Class Stats
 		if(itempos   == CENTERRIGHT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (-sPush-fnt.StringWidth(items),  crHeight+textSize*centerRightTotal++) ,items,alphaFloat);
 		if(timepos   == CENTERRIGHT) DrawStatLine(sfnt,                          Font.CR_WHITE, (-sPush-fnt.StringWidth(time),   crHeight+textSize*centerRightTotal++) ,time,alphaFloat);
 		if(powerpos  == CENTERRIGHT)
-			for(int i = 0; i < PowerupStrings.size(); i++)	
+			for(int i = 0; i < PowerupStrings.size(); i++)
 				DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
 				(-sPush-fnt.StringWidth(PowerupStrings[i]), crHeight+textSize*centerRightTotal++), PowerupStrings[i],alphaFloat);
+
+		// Bottom Left+Right "Cozy"-specific positioning per font (a bit hacky, but works well)
+		int sPushFontDefault = (VirtualWidth / 2) - 124;
+		int bHeightFontDefault = 9;
+		int sPushFontConsole = (VirtualWidth / 2) - 252;
+		int bHeightFontConsole = 18;
+		int sPushFontStatus = (VirtualWidth / 2) - 179;
+		int bHeightFontStatus = 9;
+		int sPushFontMementoMori = (VirtualWidth / 2) - 311;
+		int bHeightFontMementoMori = 19;
+
 		// Bottom Left
 		int bottomLeftTotal = 0;
 		int bHeightL =  !splitHUD.getint() || state == HUD_StatusBar  ?  sfnt.bHeightL[0] : sfnt.bHeightL[1];
-		if(itempos   == BOTTOMLEFT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,items,alphaFloat);
-		if(secretpos == BOTTOMLEFT) DrawStatLine(sfnt, secretComp ? compColor : Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,secrets,alphaFloat);
-		if(killpos   == BOTTOMLEFT) DrawStatLine(sfnt, killComp   ? compColor : Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,kills,alphaFloat);
-		if(timepos   == BOTTOMLEFT) DrawStatLine(sfnt,                          Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,time,alphaFloat);
-		if(powerpos  == BOTTOMLEFT)
-			for(int i = 0; i < PowerupStrings.size(); i++)	
-				DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
-				(sPush,-bHeightL-textSize*bottomLeftTotal++), PowerupStrings[i],alphaFloat);
+		// Reposition based on Stats font setting
+		if(cozypos && !splitHUD.getint()) {
+			switch(statsFont.GetInt())
+			{
+				// Default Font
+				case 0:
+					sPush = sPushFontDefault;
+					bHeightL = bHeightFontDefault;
+					break;
+				// Console Font
+				case 1:
+					sPush = sPushFontConsole;
+					bHeightL = bHeightFontConsole;
+					break;
+				// Status Report Font
+				case 2:
+					sPush = sPushFontStatus;
+					bHeightL = bHeightFontStatus;
+					break;
+				// Memento Mori 2 Font
+				case 3:
+					sPush = sPushFontMementoMori;
+					bHeightL = bHeightFontMementoMori;
+					break;
+			}
+			if(itempos   == BOTTOMLEFT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (sPush-fnt.StringWidth(items),-bHeightL-textSize*bottomLeftTotal++) ,items,alphaFloat);
+			if(secretpos == BOTTOMLEFT) DrawStatLine(sfnt, secretComp ? compColor : Font.CR_WHITE, (sPush-fnt.StringWidth(secrets),-bHeightL-textSize*bottomLeftTotal++) ,secrets,alphaFloat);
+			if(killpos   == BOTTOMLEFT) DrawStatLine(sfnt, killComp   ? compColor : Font.CR_WHITE, (sPush-fnt.StringWidth(kills),-bHeightL-textSize*bottomLeftTotal++) ,kills,alphaFloat);
+			if(timepos   == BOTTOMLEFT) DrawStatLine(sfnt,                          Font.CR_WHITE, (sPush-fnt.StringWidth(time),-bHeightL-textSize*bottomLeftTotal++) ,time,alphaFloat);
+			if(powerpos  == BOTTOMLEFT)
+				for(int i = 0; i < PowerupStrings.size(); i++) {
+					DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
+					(sPush-fnt.StringWidth(PowerupStrings[i]),-bHeightL-textSize*bottomLeftTotal++), PowerupStrings[i],alphaFloat);}
+		} else {
+			if(itempos   == BOTTOMLEFT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,items,alphaFloat);
+			if(secretpos == BOTTOMLEFT) DrawStatLine(sfnt, secretComp ? compColor : Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,secrets,alphaFloat);
+			if(killpos   == BOTTOMLEFT) DrawStatLine(sfnt, killComp   ? compColor : Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,kills,alphaFloat);
+			if(timepos   == BOTTOMLEFT) DrawStatLine(sfnt,                          Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,time,alphaFloat);
+			if(powerpos  == BOTTOMLEFT)
+				for(int i = 0; i < PowerupStrings.size(); i++)
+					DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
+					(sPush,-bHeightL-textSize*bottomLeftTotal++), PowerupStrings[i],alphaFloat);
+		}
+
 		// Bottom Right
 		int bottomRightTotal = 0;
 		int bHeightR =  !splitHUD.getint() || state == HUD_StatusBar  ?  sfnt.bHeightR[0] : sfnt.bHeightR[1];
 		// Split arms block stats in Heretic, move them up in this case.
 		if( (gameinfo.gametype & GAME_Heretic) && splitHUD.getint() && splitArms.getint() && state == HUD_Fullscreen)
 			bHeightR += sfnt.armsOffset;
-		if(itempos   == BOTTOMRIGHT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (-sPush-fnt.StringWidth(items),  -bHeightR-textSize*bottomRightTotal++)  ,items,alphaFloat);
-		if(secretpos == BOTTOMRIGHT) DrawStatLine(sfnt, secretComp ? compColor : Font.CR_WHITE, (-sPush-fnt.StringWidth(secrets),-bHeightR-textSize*bottomRightTotal++),secrets,alphaFloat);
-		if(killpos   == BOTTOMRIGHT) DrawStatLine(sfnt, killComp   ? compColor : Font.CR_WHITE, (-sPush-fnt.StringWidth(kills),  -bHeightR-textSize*bottomRightTotal++)  ,kills,alphaFloat);
-		if(timepos   == BOTTOMRIGHT) DrawStatLine(sfnt,                          Font.CR_WHITE, (-sPush-fnt.StringWidth(time),   -bHeightR-textSize*bottomRightTotal++)   ,time,alphaFloat);
-		if(powerpos  == BOTTOMRIGHT)
-			for(int i = 0; i < PowerupStrings.size(); i++)	
-				DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
-				(-sPush-fnt.StringWidth(PowerupStrings[i]),-bHeightR-textSize*bottomRightTotal++), PowerupStrings[i],alphaFloat);
+		// Reposition based on Stats font setting
+		if(cozypos && !splitHUD.getint()) {
+			switch(statsFont.GetInt())
+			{
+				// Default Font
+				case 0:
+					sPush = sPushFontDefault;
+					bHeightR = bHeightFontDefault;
+					break;
+				// Console Font
+				case 1:
+					sPush = sPushFontConsole;
+					bHeightR = bHeightFontConsole;
+					break;
+				// Status Report Font
+				case 2:
+					sPush = sPushFontStatus;
+					bHeightR = bHeightFontStatus;
+					break;
+				// Memento Mori 2 Font
+				case 3:
+					sPush = sPushFontMementoMori;
+					bHeightR = bHeightFontMementoMori;
+					break;
+			}
+			if(itempos   == BOTTOMRIGHT) DrawStatLine(sfnt, itemComp ? compColor   : Font.CR_WHITE, (-sPush, -bHeightR-textSize*bottomRightTotal++) ,items,alphaFloat);
+			if(secretpos == BOTTOMRIGHT) DrawStatLine(sfnt, secretComp ? compColor : Font.CR_WHITE, (-sPush, -bHeightR-textSize*bottomRightTotal++) ,secrets,alphaFloat);
+			if(killpos   == BOTTOMRIGHT) DrawStatLine(sfnt, killComp   ? compColor : Font.CR_WHITE, (-sPush, -bHeightR-textSize*bottomRightTotal++) ,kills,alphaFloat);
+			if(timepos   == BOTTOMRIGHT) DrawStatLine(sfnt,                          Font.CR_WHITE, (-sPush, -bHeightR-textSize*bottomRightTotal++) ,time,alphaFloat);
+			if(powerpos  == BOTTOMRIGHT)
+				for(int i = 0; i < PowerupStrings.size(); i++)
+					DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW, (-sPush,-bHeightR-textSize*bottomRightTotal++), PowerupStrings[i],alphaFloat);
+		} else {
+			if(itempos   == BOTTOMRIGHT) DrawStatLine(sfnt, itemComp ? compColor   : Font.CR_WHITE, (-sPush-fnt.StringWidth(items),  -bHeightR-textSize*bottomRightTotal++),items,alphaFloat);
+			if(secretpos == BOTTOMRIGHT) DrawStatLine(sfnt, secretComp ? compColor : Font.CR_WHITE, (-sPush-fnt.StringWidth(secrets),-bHeightR-textSize*bottomRightTotal++),secrets,alphaFloat);
+			if(killpos   == BOTTOMRIGHT) DrawStatLine(sfnt, killComp   ? compColor : Font.CR_WHITE, (-sPush-fnt.StringWidth(kills),  -bHeightR-textSize*bottomRightTotal++)  ,kills,alphaFloat);
+			if(timepos   == BOTTOMRIGHT) DrawStatLine(sfnt,                          Font.CR_WHITE, (-sPush-fnt.StringWidth(time),   -bHeightR-textSize*bottomRightTotal++)   ,time,alphaFloat);
+			if(powerpos  == BOTTOMRIGHT)
+				for(int i = 0; i < PowerupStrings.size(); i++)
+					DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW, (-sPush-fnt.StringWidth(PowerupStrings[i]),-bHeightR-textSize*bottomRightTotal++), PowerupStrings[i],alphaFloat);
+		}
 	}
 
 	// =====================================================
@@ -475,7 +561,7 @@ mixin Class Stats
 
 		int scaleval;
 		// if (con_scale > 0) scaleval = !LZDoom ? (con_scale+1) / 2 : con_scale;
-		// else 
+		// else
 		if (uiscale == 0)
 		{
 			// Default should try to scale to 640x400
@@ -491,14 +577,14 @@ mixin Class Stats
 		int max = MAX(vmax, hmax);
 		return NewConsoleFont.GetHeight()*MAX(1, MIN(scaleval, max));
 	}
-	
+
 	// ==========================================================
 	// Helper Function to make string a specific length in a font
 	// ==========================================================
 	String makeLength(string input, font fnt, int length, string extender = ":")
 	{
 		if(fnt.StringWidth(input) > length) return input;
-		
+
 		int spacelength = (length - fnt.StringWidth(input))/fnt.StringWidth(" ");
 		string replacer = string.format(string.format("%%s%%%ds",spacelength), extender, "");
 		input.replace(extender,replacer);

--- a/zscript/stats/stats.zs
+++ b/zscript/stats/stats.zs
@@ -7,7 +7,7 @@ mixin Class Stats
 		COUNTDOWN = 2,
 		FRACTION = 3
 	}
-	
+
 	enum StatsColorValues
 	{
 		NONE = 0,
@@ -21,19 +21,19 @@ mixin Class Stats
 		CYAN = 8,
 		FIRE = 9,
 		GOLD = 10,
-		DARKGRAY = 11, 
+		DARKGRAY = 11,
 		GREEN = 12,
-		DARKGREEN = 13, 
+		DARKGREEN = 13,
 		OLIVE = 14,
 		ORANGE = 15,
 		PURPLE = 16,
 		RED = 17,
-		DARKRED = 18, 
+		DARKRED = 18,
 		SAPPHIRE = 19,
 		TEAL = 20,
 		YELLOW = 21
 	}
-	
+
 	enum StatsPosition
 	{
 		OFF = 0,
@@ -42,7 +42,9 @@ mixin Class Stats
 		CENTERLEFT = 3,
 		CENTERRIGHT = 4,
 		BOTTOMLEFT = 5,
-		BOTTOMRIGHT = 6
+		BOTTOMRIGHT = 6,
+		SBARLEFT = 7,
+		SBARRIGHT = 8
 	}
 
 	DynamicValueInterpolator siKillsP;
@@ -134,27 +136,27 @@ mixin Class Stats
 	void DrawStatLine(statFont sfnt, int cr, Vector2 pos, String text, double alpha)
 	{
 		Vector2 scale = GetHUDScale();
-		
+
 		// These values are jury-rigged; they were initially designed for my personal settings before becoming generic
 		int VirtualWidth  = int(sfnt.scale.x * 6.0/scale.x * Screen.GetWidth() /2560);
 		int VirtualHeight = int(sfnt.scale.y * 7.2/scale.y * Screen.GetHeight()/1440);
-		
+
 		int posX = int( pos.x >= 0 ? pos.x : VirtualWidth  + pos.x );
 		int posY = int( pos.y >= 0 ? pos.y : VirtualHeight + pos.y );
 
-		screen.DrawText(sfnt.fnt, cr, posX, posY, text, 
+		screen.DrawText(sfnt.fnt, cr, posX, posY, text,
 			DTA_KeepRatio, true,
 			DTA_VirtualWidth, VirtualWidth, DTA_VirtualHeight, VirtualHeight, DTA_Alpha, alpha);
 	}
-	
+
 	protected virtual void DrawLevelStats (statFont sfnt, int state = HUD_StatusBar)
 	{
 		int alphaO = alphaOpaque.GetInt();
 		double alphaFloat = alphaO == OP_NUM || alphaO == OP_NUMGRAPH ? 1 : 1-alphaValue.getfloat();
-		
+
 		let fnt = sfnt.fnt;
 		int padding = sfnt.padding;
-		
+
 		int compColor;
 		switch(statsCompColor.GetInt())
 		{
@@ -226,7 +228,7 @@ mixin Class Stats
 				compColor = Font.CR_YELLOW;
 				break;
 		}
-		
+
 		string kills = "";
 		string secrets = "";
 		string items = "";
@@ -235,18 +237,18 @@ mixin Class Stats
 		int mkilled   = multiplayer? CPlayer.killcount   : Level.killed_monsters;
 		int sfound    = multiplayer? CPlayer.secretcount : Level.found_secrets;
 		int ifound    = multiplayer? CPlayer.itemcount   : Level.found_items;
-		
+
 		// Format based on type specified
 		bool killComp = false;
 		bool secretComp = false;
 		bool itemComp = false;
-		string killstring    = (gameinfo.gametype & GAME_Chex) ? 
-		                       Stringtable.Localize("$FULLHUD_KILLS_CHEX") : 
+		string killstring    = (gameinfo.gametype & GAME_Chex) ?
+		                       Stringtable.Localize("$FULLHUD_KILLS_CHEX") :
 				       Stringtable.Localize("$FULLHUD_KILLS");
 		string secretstring  = Stringtable.Localize("$FULLHUD_SECRETS");
 		string itemstring    = Stringtable.Localize("$FULLHUD_ITEMS");
-		string killstring2   = (gameinfo.gametype & GAME_Chex) ? 
-		                       Stringtable.Localize("$FULLHUD_KILLS_CHEX_SHORT") : 
+		string killstring2   = (gameinfo.gametype & GAME_Chex) ?
+		                       Stringtable.Localize("$FULLHUD_KILLS_CHEX_SHORT") :
 				       Stringtable.Localize("$FULLHUD_KILLS_SHORT");
 		string secretstring2 = Stringtable.Localize("$FULLHUD_SECRETS_SHORT");
 		string itemstring2   = Stringtable.Localize("$FULLHUD_ITEMS_SHORT");
@@ -269,7 +271,7 @@ mixin Class Stats
 				if (siSecretsP.GetValue() == 100) secretComp = true;
 				if (siItemsP.GetValue()   == 100) itemComp = true;
 				break;
-				
+
 			case COUNTDOWN:
 				string space = string.format(string.format("%%%ds",padding), padding ? "" : " ");
 				string leftstring = Stringtable.Localize("$FULLHUD_LEFT_STRING");
@@ -281,7 +283,7 @@ mixin Class Stats
 				if (siSecretsC.GetValue() == 0) secretComp = true;
 				if (siItemsC.GetValue()   == 0) itemComp = true;
 				break;
-				
+
 			case FRACTION:
 				if (statKills.GetInt())   kills   = string.format("%s: %i/%i", killstring,   siKillsF.GetValue(),   Level.total_monsters);
 				if (statSecrets.GetInt()) secrets = string.format("%s: %i/%i", secretstring, siSecretsF.GetValue(), Level.total_secrets);
@@ -295,7 +297,7 @@ mixin Class Stats
 		// Format Level time
 		int hubtime = Level.time/Thinker.TICRATE;
 		if (statTime.GetInt()) time = string.format("%02d:%02d:%02d",hubtime/3600,(hubtime/60)%60,hubtime%60);
-		
+
 		// Format Powerups
 		Array<String> PowerupStrings;
 		int powerlength = 0;
@@ -327,24 +329,25 @@ mixin Class Stats
 		int itempos   = statsType.GetInt() ? statItems.getInt()    : OFF;
 		int timepos   = statsType.GetInt() ? statTime.getInt()     : OFF;
 		int powerpos  = statsType.GetInt() ? statPowerups.getInt() : OFF;
-		
+
 		// Make each block have the same length
-		int maxlength[7] = {0,0,0,0,0,0,0};
+		int maxlength[9] = {0,0,0,0,0,0,0,0,0};
 		maxlength[killpos]   = max(maxlength[killpos],  fnt.StringWidth(kills));
 		maxlength[secretpos] = max(maxlength[secretpos],fnt.StringWidth(secrets));
 		maxlength[itempos]   = max(maxlength[itempos],  fnt.StringWidth(items));
 		maxlength[powerpos]  = max(maxlength[powerpos], powerlength);
-		
+
 		kills =   makeLength(kills,  fnt, maxlength[killpos]   + padding);
 		secrets = makeLength(secrets,fnt, maxlength[secretpos] + padding);
 		items =   makeLength(items,  fnt, maxlength[itempos]   + padding);
 		for(int i = 0; i < PowerupStrings.size(); i++)
 			PowerupStrings[i] = makeLength(PowerupStrings[i],  fnt, maxlength[powerpos] + padding, ": ");
 		morphString = makeLength(morphString, fnt, maxlength[powerpos] + padding, ": ");
-		
+
 		int sPush = sfnt.sPush;
 		int tHeight = sfnt.tHeight;
 		Vector2 scale = GetHUDScale();
+		int VirtualWidth  = int(sfnt.scale.x * 6.0/scale.x * Screen.GetWidth() /2560);
 		int VirtualHeight = int(sfnt.scale.y * 7.2/scale.y * Screen.GetHeight()/1440);
 		// Top Left
 		int topLeftTotal = 0;
@@ -353,7 +356,7 @@ mixin Class Stats
 		if(itempos   == TOPLEFT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (sPush,tHeight+textSize*topLeftTotal++) ,items,alphaFloat);
 		if(timepos   == TOPLEFT) DrawStatLine(sfnt,                          Font.CR_WHITE, (sPush,tHeight+textSize*topLeftTotal++) ,time,alphaFloat);
 		if(powerpos  == TOPLEFT)
-			for(int i = 0; i < PowerupStrings.size(); i++)	
+			for(int i = 0; i < PowerupStrings.size(); i++)
 				DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
 				(sPush,tHeight+textSize*topLeftTotal++), PowerupStrings[i],alphaFloat);
 		// Top Right
@@ -365,7 +368,7 @@ mixin Class Stats
 		if(itempos   == TOPRIGHT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (-sPush-fnt.StringWidth(items),  conOffset+tHeight+textSize*topRightTotal++)  ,items,alphaFloat);
 		if(timepos   == TOPRIGHT) DrawStatLine(sfnt,                          Font.CR_WHITE, (-sPush-fnt.StringWidth(time),   conOffset+tHeight+textSize*topRightTotal++)   ,time,alphaFloat);
 		if(powerpos  == TOPRIGHT)
-			for(int i = 0; i < PowerupStrings.size(); i++)	
+			for(int i = 0; i < PowerupStrings.size(); i++)
 				DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
 				(-sPush-fnt.StringWidth(PowerupStrings[i]),conOffset+tHeight+textSize*topRightTotal++), PowerupStrings[i],alphaFloat);
 		// Center Left
@@ -382,7 +385,7 @@ mixin Class Stats
 		if(itempos   == CENTERLEFT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (sPush,clHeight+textSize*centerLeftTotal++) ,items,alphaFloat);
 		if(timepos   == CENTERLEFT) DrawStatLine(sfnt,                          Font.CR_WHITE, (sPush,clHeight+textSize*centerLeftTotal++) ,time,alphaFloat);
 		if(powerpos  == CENTERLEFT)
-			for(int i = 0; i < PowerupStrings.size(); i++)	
+			for(int i = 0; i < PowerupStrings.size(); i++)
 				DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
 				(sPush,clHeight+textSize*centerLeftTotal++), PowerupStrings[i],alphaFloat);
 		// Center Right
@@ -399,7 +402,7 @@ mixin Class Stats
 		if(itempos   == CENTERRIGHT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (-sPush-fnt.StringWidth(items),  crHeight+textSize*centerRightTotal++) ,items,alphaFloat);
 		if(timepos   == CENTERRIGHT) DrawStatLine(sfnt,                          Font.CR_WHITE, (-sPush-fnt.StringWidth(time),   crHeight+textSize*centerRightTotal++) ,time,alphaFloat);
 		if(powerpos  == CENTERRIGHT)
-			for(int i = 0; i < PowerupStrings.size(); i++)	
+			for(int i = 0; i < PowerupStrings.size(); i++)
 				DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
 				(-sPush-fnt.StringWidth(PowerupStrings[i]), crHeight+textSize*centerRightTotal++), PowerupStrings[i],alphaFloat);
 		// Bottom Left
@@ -410,7 +413,7 @@ mixin Class Stats
 		if(killpos   == BOTTOMLEFT) DrawStatLine(sfnt, killComp   ? compColor : Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,kills,alphaFloat);
 		if(timepos   == BOTTOMLEFT) DrawStatLine(sfnt,                          Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,time,alphaFloat);
 		if(powerpos  == BOTTOMLEFT)
-			for(int i = 0; i < PowerupStrings.size(); i++)	
+			for(int i = 0; i < PowerupStrings.size(); i++)
 				DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
 				(sPush,-bHeightL-textSize*bottomLeftTotal++), PowerupStrings[i],alphaFloat);
 		// Bottom Right
@@ -424,9 +427,191 @@ mixin Class Stats
 		if(killpos   == BOTTOMRIGHT) DrawStatLine(sfnt, killComp   ? compColor : Font.CR_WHITE, (-sPush-fnt.StringWidth(kills),  -bHeightR-textSize*bottomRightTotal++)  ,kills,alphaFloat);
 		if(timepos   == BOTTOMRIGHT) DrawStatLine(sfnt,                          Font.CR_WHITE, (-sPush-fnt.StringWidth(time),   -bHeightR-textSize*bottomRightTotal++)   ,time,alphaFloat);
 		if(powerpos  == BOTTOMRIGHT)
-			for(int i = 0; i < PowerupStrings.size(); i++)	
+			for(int i = 0; i < PowerupStrings.size(); i++)
 				DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
 				(-sPush-fnt.StringWidth(PowerupStrings[i]),-bHeightR-textSize*bottomRightTotal++), PowerupStrings[i],alphaFloat);
+
+		// Status Bar (Left/Right)
+		// Initialize vars for left/right positioning per font
+		int sPushFontDefault = (VirtualWidth / 2) - 124;
+		int sPushFontConsole = (VirtualWidth / 2) - 252;
+		int sPushFontStatus = (VirtualWidth / 2) - 179;
+		int sPushFontMementoMori = (VirtualWidth / 2) - 311;
+
+		// Setup correct values for left/right positioning based on whether Split Bar/Fullscreen is enabled
+		if (splitHUD.getint() && screenSize.getInt() > 10) {
+			sPushFontDefault = 111;
+			sPushFontConsole = 225;
+			sPushFontStatus = 160;
+			sPushFontMementoMori = 277;
+		}
+
+		// Heretic/Hexen-specific modifications
+		if (gameinfo.gametype & GAME_Hexen || gameinfo.gametype & GAME_Heretic) {
+			sPushFontDefault = (VirtualWidth / 2) - 147;
+			sPushFontConsole = (VirtualWidth / 2) - 300;
+			sPushFontStatus = (VirtualWidth / 2) - 213;
+			sPushFontMementoMori = (VirtualWidth / 2) - 370;
+		}
+
+		if ((gameinfo.gametype & GAME_Hexen || gameinfo.gametype & GAME_Heretic) && (splitHUD.getint() && screenSize.getInt() > 10)) {
+			sPushFontDefault = 76;
+			sPushFontConsole = 152;
+			sPushFontStatus = 108;
+			sPushFontMementoMori = 185;
+		}
+
+		// Setup correct values for height positioning from bottom viewport edge
+		int bHeightFontDefault = 9;
+		int bHeightFontConsole = 18;
+		int bHeightFontStatus = 9;
+		int bHeightFontMementoMori = 19;
+
+		// Status Bar (Left)
+		switch(statsFont.GetInt())
+		{
+			// Default Font
+			case 0:
+				sPush = sPushFontDefault;
+				bHeightL = bHeightFontDefault;
+				break;
+			// Console Font
+			case 1:
+				sPush = sPushFontConsole;
+				bHeightL = bHeightFontConsole;
+				break;
+			// Status Report Font
+			case 2:
+				sPush = sPushFontStatus;
+				bHeightL = bHeightFontStatus;
+				break;
+			// Memento Mori 2 Font
+			case 3:
+				sPush = sPushFontMementoMori;
+				bHeightL = bHeightFontMementoMori;
+				break;
+		}
+
+		// Slight offset for Hexen when stats are Status Bar (Right) and fullscreen
+		// 		and player has an inventory item, or is browsing inventory
+		if (gameinfo.gametype & GAME_Hexen && (splitHUD.getint() && screenSize.getInt() > 10) && isInventoryBarVisible()) {
+			sPush = 1000;
+		}
+
+		bottomLeftTotal = 0;
+		if (splitHUD.getint() && screenSize.getInt() > 10) {
+			if (itempos   == SBARLEFT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,items,alphaFloat);
+			if (secretpos == SBARLEFT) DrawStatLine(sfnt, secretComp ? compColor : Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,secrets,alphaFloat);
+			if (killpos   == SBARLEFT) DrawStatLine(sfnt, killComp   ? compColor : Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,kills,alphaFloat);
+			if (timepos   == SBARLEFT) DrawStatLine(sfnt,                          Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,time,alphaFloat);
+			if(powerpos   == SBARLEFT)
+				for(int i = 0; i < PowerupStrings.size(); i++) {
+					DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
+					(sPush,-bHeightL-textSize*bottomLeftTotal++), PowerupStrings[i],alphaFloat);
+				}
+		}
+		if (!splitHUD.getint() || (splitHUD.getint() && screenSize.getInt() <= 10)) {
+			if(itempos     == SBARLEFT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (sPush-fnt.StringWidth(items),-bHeightL-textSize*bottomLeftTotal++) ,items,alphaFloat);
+			if(secretpos   == SBARLEFT) DrawStatLine(sfnt, secretComp ? compColor : Font.CR_WHITE, (sPush-fnt.StringWidth(secrets),-bHeightL-textSize*bottomLeftTotal++) ,secrets,alphaFloat);
+			if(killpos     == SBARLEFT) DrawStatLine(sfnt, killComp   ? compColor : Font.CR_WHITE, (sPush-fnt.StringWidth(kills),-bHeightL-textSize*bottomLeftTotal++) ,kills,alphaFloat);
+			if(timepos     == SBARLEFT) DrawStatLine(sfnt,                          Font.CR_WHITE, (sPush-fnt.StringWidth(time),-bHeightL-textSize*bottomLeftTotal++) ,time,alphaFloat);
+			if(powerpos    == SBARLEFT)
+				for(int i = 0; i < PowerupStrings.size(); i++) {
+					DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
+					(sPush-fnt.StringWidth(PowerupStrings[i]),-bHeightL-textSize*bottomLeftTotal++), PowerupStrings[i],alphaFloat);
+				}
+		}
+
+		// Status Bar (Right)
+		switch(statsFont.GetInt())
+		{
+			// Default Font
+			case 0:
+				sPush = sPushFontDefault;
+				bHeightR = bHeightFontDefault;
+				break;
+			// Console Font
+			case 1:
+				sPush = sPushFontConsole;
+				bHeightR = bHeightFontConsole;
+				break;
+			// Status Report Font
+			case 2:
+				sPush = sPushFontStatus;
+				bHeightR = bHeightFontStatus;
+				break;
+			// Memento Mori 2 Font
+			case 3:
+				sPush = sPushFontMementoMori;
+				bHeightR = bHeightFontMementoMori;
+				break;
+		}
+
+		// Slight offset for Heretic when stats are Status Bar (Right) and fullscreen
+		if (gameinfo.gametype & GAME_Heretic && (splitHUD.getint() && screenSize.getInt() > 10)) {
+			switch(statsFont.GetInt())
+			{
+				case 0:
+					break;
+				case 1:
+					sPush = sPush + 20;
+					break;
+				case 2:
+					sPush = sPush + 14;
+					break;
+				case 3:
+					sPush = sPush + 26;
+					break;
+			}
+		}
+		// Slight offset for Hexen when stats are Status Bar (Right) and fullscreen
+		// 		and player has an inventory item, or is browsing inventory
+		if (gameinfo.gametype & GAME_Hexen && (splitHUD.getint() && screenSize.getInt() > 10)) {
+			if (CPlayer.mo.InvSel != null && !Level.NoInventoryBar) {
+				switch(statsFont.GetInt())
+				{
+					case 0:
+						sPush = sPush + 18;
+						break;
+					case 1:
+						sPush = sPush + 37;
+						break;
+					case 2:
+						sPush = sPush + 26;
+						break;
+					case 3:
+						sPush = sPush + 50;
+						break;
+				}
+			}
+			if (isInventoryBarVisible()) {
+				sPush = 1000;
+			}
+		}
+
+		bottomRightTotal = 0;
+		if (splitHUD.getint() && screenSize.getInt() > 10) {
+			if (itempos   == SBARRIGHT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (-sPush-fnt.StringWidth(items),-bHeightR-textSize*bottomRightTotal++) ,items,alphaFloat);
+			if (secretpos == SBARRIGHT) DrawStatLine(sfnt, secretComp ? compColor : Font.CR_WHITE, (-sPush-fnt.StringWidth(secrets),-bHeightR-textSize*bottomRightTotal++) ,secrets,alphaFloat);
+			if (killpos   == SBARRIGHT) DrawStatLine(sfnt, killComp   ? compColor : Font.CR_WHITE, (-sPush-fnt.StringWidth(kills),-bHeightR-textSize*bottomRightTotal++) ,kills,alphaFloat);
+			if (timepos   == SBARRIGHT) DrawStatLine(sfnt,                          Font.CR_WHITE, (-sPush-fnt.StringWidth(time),-bHeightR-textSize*bottomRightTotal++) ,time,alphaFloat);
+			if(powerpos   == SBARRIGHT)
+				for(int i = 0; i < PowerupStrings.size(); i++) {
+					DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
+					(-sPush-fnt.StringWidth(PowerupStrings[i]),-bHeightR-textSize*bottomRightTotal++), PowerupStrings[i],alphaFloat);
+				}
+		}
+		if (!splitHUD.getint() || (splitHUD.getint() && screenSize.getInt() <= 10)) {
+			if(itempos     == SBARRIGHT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (-sPush,-bHeightR-textSize*bottomRightTotal++) ,items,alphaFloat);
+			if(secretpos   == SBARRIGHT) DrawStatLine(sfnt, secretComp ? compColor : Font.CR_WHITE, (-sPush,-bHeightR-textSize*bottomRightTotal++) ,secrets,alphaFloat);
+			if(killpos     == SBARRIGHT) DrawStatLine(sfnt, killComp   ? compColor : Font.CR_WHITE, (-sPush,-bHeightR-textSize*bottomRightTotal++) ,kills,alphaFloat);
+			if(timepos     == SBARRIGHT) DrawStatLine(sfnt,                          Font.CR_WHITE, (-sPush,-bHeightR-textSize*bottomRightTotal++) ,time,alphaFloat);
+			if(powerpos    == SBARRIGHT)
+				for(int i = 0; i < PowerupStrings.size(); i++) {
+					DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
+					(-sPush,-bHeightR-textSize*bottomRightTotal++), PowerupStrings[i],alphaFloat);
+				}
+		}
 	}
 
 	// =====================================================
@@ -475,7 +660,7 @@ mixin Class Stats
 
 		int scaleval;
 		// if (con_scale > 0) scaleval = !LZDoom ? (con_scale+1) / 2 : con_scale;
-		// else 
+		// else
 		if (uiscale == 0)
 		{
 			// Default should try to scale to 640x400
@@ -491,14 +676,14 @@ mixin Class Stats
 		int max = MAX(vmax, hmax);
 		return NewConsoleFont.GetHeight()*MAX(1, MIN(scaleval, max));
 	}
-	
+
 	// ==========================================================
 	// Helper Function to make string a specific length in a font
 	// ==========================================================
 	String makeLength(string input, font fnt, int length, string extender = ":")
 	{
 		if(fnt.StringWidth(input) > length) return input;
-		
+
 		int spacelength = (length - fnt.StringWidth(input))/fnt.StringWidth(" ");
 		string replacer = string.format(string.format("%%s%%%ds",spacelength), extender, "");
 		input.replace(extender,replacer);

--- a/zscript/stats/stats.zs
+++ b/zscript/stats/stats.zs
@@ -7,7 +7,7 @@ mixin Class Stats
 		COUNTDOWN = 2,
 		FRACTION = 3
 	}
-
+	
 	enum StatsColorValues
 	{
 		NONE = 0,
@@ -21,19 +21,19 @@ mixin Class Stats
 		CYAN = 8,
 		FIRE = 9,
 		GOLD = 10,
-		DARKGRAY = 11,
+		DARKGRAY = 11, 
 		GREEN = 12,
-		DARKGREEN = 13,
+		DARKGREEN = 13, 
 		OLIVE = 14,
 		ORANGE = 15,
 		PURPLE = 16,
 		RED = 17,
-		DARKRED = 18,
+		DARKRED = 18, 
 		SAPPHIRE = 19,
 		TEAL = 20,
 		YELLOW = 21
 	}
-
+	
 	enum StatsPosition
 	{
 		OFF = 0,
@@ -134,27 +134,27 @@ mixin Class Stats
 	void DrawStatLine(statFont sfnt, int cr, Vector2 pos, String text, double alpha)
 	{
 		Vector2 scale = GetHUDScale();
-
+		
 		// These values are jury-rigged; they were initially designed for my personal settings before becoming generic
 		int VirtualWidth  = int(sfnt.scale.x * 6.0/scale.x * Screen.GetWidth() /2560);
 		int VirtualHeight = int(sfnt.scale.y * 7.2/scale.y * Screen.GetHeight()/1440);
-
+		
 		int posX = int( pos.x >= 0 ? pos.x : VirtualWidth  + pos.x );
 		int posY = int( pos.y >= 0 ? pos.y : VirtualHeight + pos.y );
 
-		screen.DrawText(sfnt.fnt, cr, posX, posY, text,
+		screen.DrawText(sfnt.fnt, cr, posX, posY, text, 
 			DTA_KeepRatio, true,
 			DTA_VirtualWidth, VirtualWidth, DTA_VirtualHeight, VirtualHeight, DTA_Alpha, alpha);
 	}
-
+	
 	protected virtual void DrawLevelStats (statFont sfnt, int state = HUD_StatusBar)
 	{
 		int alphaO = alphaOpaque.GetInt();
 		double alphaFloat = alphaO == OP_NUM || alphaO == OP_NUMGRAPH ? 1 : 1-alphaValue.getfloat();
-
+		
 		let fnt = sfnt.fnt;
 		int padding = sfnt.padding;
-
+		
 		int compColor;
 		switch(statsCompColor.GetInt())
 		{
@@ -226,7 +226,7 @@ mixin Class Stats
 				compColor = Font.CR_YELLOW;
 				break;
 		}
-
+		
 		string kills = "";
 		string secrets = "";
 		string items = "";
@@ -235,18 +235,18 @@ mixin Class Stats
 		int mkilled   = multiplayer? CPlayer.killcount   : Level.killed_monsters;
 		int sfound    = multiplayer? CPlayer.secretcount : Level.found_secrets;
 		int ifound    = multiplayer? CPlayer.itemcount   : Level.found_items;
-
+		
 		// Format based on type specified
 		bool killComp = false;
 		bool secretComp = false;
 		bool itemComp = false;
-		string killstring    = (gameinfo.gametype & GAME_Chex) ?
-		                       Stringtable.Localize("$FULLHUD_KILLS_CHEX") :
+		string killstring    = (gameinfo.gametype & GAME_Chex) ? 
+		                       Stringtable.Localize("$FULLHUD_KILLS_CHEX") : 
 				       Stringtable.Localize("$FULLHUD_KILLS");
 		string secretstring  = Stringtable.Localize("$FULLHUD_SECRETS");
 		string itemstring    = Stringtable.Localize("$FULLHUD_ITEMS");
-		string killstring2   = (gameinfo.gametype & GAME_Chex) ?
-		                       Stringtable.Localize("$FULLHUD_KILLS_CHEX_SHORT") :
+		string killstring2   = (gameinfo.gametype & GAME_Chex) ? 
+		                       Stringtable.Localize("$FULLHUD_KILLS_CHEX_SHORT") : 
 				       Stringtable.Localize("$FULLHUD_KILLS_SHORT");
 		string secretstring2 = Stringtable.Localize("$FULLHUD_SECRETS_SHORT");
 		string itemstring2   = Stringtable.Localize("$FULLHUD_ITEMS_SHORT");
@@ -269,7 +269,7 @@ mixin Class Stats
 				if (siSecretsP.GetValue() == 100) secretComp = true;
 				if (siItemsP.GetValue()   == 100) itemComp = true;
 				break;
-
+				
 			case COUNTDOWN:
 				string space = string.format(string.format("%%%ds",padding), padding ? "" : " ");
 				string leftstring = Stringtable.Localize("$FULLHUD_LEFT_STRING");
@@ -281,7 +281,7 @@ mixin Class Stats
 				if (siSecretsC.GetValue() == 0) secretComp = true;
 				if (siItemsC.GetValue()   == 0) itemComp = true;
 				break;
-
+				
 			case FRACTION:
 				if (statKills.GetInt())   kills   = string.format("%s: %i/%i", killstring,   siKillsF.GetValue(),   Level.total_monsters);
 				if (statSecrets.GetInt()) secrets = string.format("%s: %i/%i", secretstring, siSecretsF.GetValue(), Level.total_secrets);
@@ -295,7 +295,7 @@ mixin Class Stats
 		// Format Level time
 		int hubtime = Level.time/Thinker.TICRATE;
 		if (statTime.GetInt()) time = string.format("%02d:%02d:%02d",hubtime/3600,(hubtime/60)%60,hubtime%60);
-
+		
 		// Format Powerups
 		Array<String> PowerupStrings;
 		int powerlength = 0;
@@ -321,34 +321,31 @@ mixin Class Stats
 			powerlength = max(powerlength, fnt.StringWidth(morphString));
 		}
 
-		int textSize  = fnt.GetHeight() + sfnt.vspace;
+		int textSize = fnt.GetHeight() + sfnt.vspace;
 		int killpos   = statsType.GetInt() ? statKills.getInt()    : OFF;
 		int secretpos = statsType.GetInt() ? statSecrets.getInt()  : OFF;
 		int itempos   = statsType.GetInt() ? statItems.getInt()    : OFF;
 		int timepos   = statsType.GetInt() ? statTime.getInt()     : OFF;
 		int powerpos  = statsType.GetInt() ? statPowerups.getInt() : OFF;
-		int cozypos   = statsType.GetInt() ? statsCozy.getInt()    : OFF;
-
+		
 		// Make each block have the same length
 		int maxlength[7] = {0,0,0,0,0,0,0};
 		maxlength[killpos]   = max(maxlength[killpos],  fnt.StringWidth(kills));
 		maxlength[secretpos] = max(maxlength[secretpos],fnt.StringWidth(secrets));
 		maxlength[itempos]   = max(maxlength[itempos],  fnt.StringWidth(items));
 		maxlength[powerpos]  = max(maxlength[powerpos], powerlength);
-
+		
 		kills =   makeLength(kills,  fnt, maxlength[killpos]   + padding);
 		secrets = makeLength(secrets,fnt, maxlength[secretpos] + padding);
 		items =   makeLength(items,  fnt, maxlength[itempos]   + padding);
 		for(int i = 0; i < PowerupStrings.size(); i++)
 			PowerupStrings[i] = makeLength(PowerupStrings[i],  fnt, maxlength[powerpos] + padding, ": ");
 		morphString = makeLength(morphString, fnt, maxlength[powerpos] + padding, ": ");
-
+		
 		int sPush = sfnt.sPush;
 		int tHeight = sfnt.tHeight;
 		Vector2 scale = GetHUDScale();
-		int VirtualWidth  = int(sfnt.scale.x * 6.0/scale.x * Screen.GetWidth() /2560);
 		int VirtualHeight = int(sfnt.scale.y * 7.2/scale.y * Screen.GetHeight()/1440);
-
 		// Top Left
 		int topLeftTotal = 0;
 		if(killpos   == TOPLEFT) DrawStatLine(sfnt, killComp   ? compColor : Font.CR_WHITE, (sPush,tHeight+textSize*topLeftTotal++) ,kills,alphaFloat);
@@ -356,10 +353,9 @@ mixin Class Stats
 		if(itempos   == TOPLEFT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (sPush,tHeight+textSize*topLeftTotal++) ,items,alphaFloat);
 		if(timepos   == TOPLEFT) DrawStatLine(sfnt,                          Font.CR_WHITE, (sPush,tHeight+textSize*topLeftTotal++) ,time,alphaFloat);
 		if(powerpos  == TOPLEFT)
-			for(int i = 0; i < PowerupStrings.size(); i++)
+			for(int i = 0; i < PowerupStrings.size(); i++)	
 				DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
 				(sPush,tHeight+textSize*topLeftTotal++), PowerupStrings[i],alphaFloat);
-
 		// Top Right
 		// This needs special handling for vid_fps
 		int conOffset = vid_fps ? GetConSize() * VirtualHeight/Screen.GetHeight() : 0;
@@ -369,10 +365,9 @@ mixin Class Stats
 		if(itempos   == TOPRIGHT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (-sPush-fnt.StringWidth(items),  conOffset+tHeight+textSize*topRightTotal++)  ,items,alphaFloat);
 		if(timepos   == TOPRIGHT) DrawStatLine(sfnt,                          Font.CR_WHITE, (-sPush-fnt.StringWidth(time),   conOffset+tHeight+textSize*topRightTotal++)   ,time,alphaFloat);
 		if(powerpos  == TOPRIGHT)
-			for(int i = 0; i < PowerupStrings.size(); i++)
+			for(int i = 0; i < PowerupStrings.size(); i++)	
 				DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
 				(-sPush-fnt.StringWidth(PowerupStrings[i]),conOffset+tHeight+textSize*topRightTotal++), PowerupStrings[i],alphaFloat);
-
 		// Center Left
 		int clTotal = 0;
 		if(itempos   == CENTERLEFT) clTotal++;
@@ -387,10 +382,9 @@ mixin Class Stats
 		if(itempos   == CENTERLEFT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (sPush,clHeight+textSize*centerLeftTotal++) ,items,alphaFloat);
 		if(timepos   == CENTERLEFT) DrawStatLine(sfnt,                          Font.CR_WHITE, (sPush,clHeight+textSize*centerLeftTotal++) ,time,alphaFloat);
 		if(powerpos  == CENTERLEFT)
-			for(int i = 0; i < PowerupStrings.size(); i++)
+			for(int i = 0; i < PowerupStrings.size(); i++)	
 				DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
 				(sPush,clHeight+textSize*centerLeftTotal++), PowerupStrings[i],alphaFloat);
-
 		// Center Right
 		int crTotal = 0;
 		if(itempos   == CENTERRIGHT) crTotal++;
@@ -405,114 +399,34 @@ mixin Class Stats
 		if(itempos   == CENTERRIGHT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (-sPush-fnt.StringWidth(items),  crHeight+textSize*centerRightTotal++) ,items,alphaFloat);
 		if(timepos   == CENTERRIGHT) DrawStatLine(sfnt,                          Font.CR_WHITE, (-sPush-fnt.StringWidth(time),   crHeight+textSize*centerRightTotal++) ,time,alphaFloat);
 		if(powerpos  == CENTERRIGHT)
-			for(int i = 0; i < PowerupStrings.size(); i++)
+			for(int i = 0; i < PowerupStrings.size(); i++)	
 				DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
 				(-sPush-fnt.StringWidth(PowerupStrings[i]), crHeight+textSize*centerRightTotal++), PowerupStrings[i],alphaFloat);
-
-		// Bottom Left+Right "Cozy"-specific positioning per font (a bit hacky, but works well)
-		int sPushFontDefault = (VirtualWidth / 2) - 124;
-		int bHeightFontDefault = 9;
-		int sPushFontConsole = (VirtualWidth / 2) - 252;
-		int bHeightFontConsole = 18;
-		int sPushFontStatus = (VirtualWidth / 2) - 179;
-		int bHeightFontStatus = 9;
-		int sPushFontMementoMori = (VirtualWidth / 2) - 311;
-		int bHeightFontMementoMori = 19;
-
 		// Bottom Left
 		int bottomLeftTotal = 0;
 		int bHeightL =  !splitHUD.getint() || state == HUD_StatusBar  ?  sfnt.bHeightL[0] : sfnt.bHeightL[1];
-		// Reposition based on Stats font setting
-		if(cozypos && !splitHUD.getint()) {
-			switch(statsFont.GetInt())
-			{
-				// Default Font
-				case 0:
-					sPush = sPushFontDefault;
-					bHeightL = bHeightFontDefault;
-					break;
-				// Console Font
-				case 1:
-					sPush = sPushFontConsole;
-					bHeightL = bHeightFontConsole;
-					break;
-				// Status Report Font
-				case 2:
-					sPush = sPushFontStatus;
-					bHeightL = bHeightFontStatus;
-					break;
-				// Memento Mori 2 Font
-				case 3:
-					sPush = sPushFontMementoMori;
-					bHeightL = bHeightFontMementoMori;
-					break;
-			}
-			if(itempos   == BOTTOMLEFT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (sPush-fnt.StringWidth(items),-bHeightL-textSize*bottomLeftTotal++) ,items,alphaFloat);
-			if(secretpos == BOTTOMLEFT) DrawStatLine(sfnt, secretComp ? compColor : Font.CR_WHITE, (sPush-fnt.StringWidth(secrets),-bHeightL-textSize*bottomLeftTotal++) ,secrets,alphaFloat);
-			if(killpos   == BOTTOMLEFT) DrawStatLine(sfnt, killComp   ? compColor : Font.CR_WHITE, (sPush-fnt.StringWidth(kills),-bHeightL-textSize*bottomLeftTotal++) ,kills,alphaFloat);
-			if(timepos   == BOTTOMLEFT) DrawStatLine(sfnt,                          Font.CR_WHITE, (sPush-fnt.StringWidth(time),-bHeightL-textSize*bottomLeftTotal++) ,time,alphaFloat);
-			if(powerpos  == BOTTOMLEFT)
-				for(int i = 0; i < PowerupStrings.size(); i++) {
-					DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
-					(sPush-fnt.StringWidth(PowerupStrings[i]),-bHeightL-textSize*bottomLeftTotal++), PowerupStrings[i],alphaFloat);}
-		} else {
-			if(itempos   == BOTTOMLEFT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,items,alphaFloat);
-			if(secretpos == BOTTOMLEFT) DrawStatLine(sfnt, secretComp ? compColor : Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,secrets,alphaFloat);
-			if(killpos   == BOTTOMLEFT) DrawStatLine(sfnt, killComp   ? compColor : Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,kills,alphaFloat);
-			if(timepos   == BOTTOMLEFT) DrawStatLine(sfnt,                          Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,time,alphaFloat);
-			if(powerpos  == BOTTOMLEFT)
-				for(int i = 0; i < PowerupStrings.size(); i++)
-					DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
-					(sPush,-bHeightL-textSize*bottomLeftTotal++), PowerupStrings[i],alphaFloat);
-		}
-
+		if(itempos   == BOTTOMLEFT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,items,alphaFloat);
+		if(secretpos == BOTTOMLEFT) DrawStatLine(sfnt, secretComp ? compColor : Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,secrets,alphaFloat);
+		if(killpos   == BOTTOMLEFT) DrawStatLine(sfnt, killComp   ? compColor : Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,kills,alphaFloat);
+		if(timepos   == BOTTOMLEFT) DrawStatLine(sfnt,                          Font.CR_WHITE, (sPush,-bHeightL-textSize*bottomLeftTotal++) ,time,alphaFloat);
+		if(powerpos  == BOTTOMLEFT)
+			for(int i = 0; i < PowerupStrings.size(); i++)	
+				DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
+				(sPush,-bHeightL-textSize*bottomLeftTotal++), PowerupStrings[i],alphaFloat);
 		// Bottom Right
 		int bottomRightTotal = 0;
 		int bHeightR =  !splitHUD.getint() || state == HUD_StatusBar  ?  sfnt.bHeightR[0] : sfnt.bHeightR[1];
 		// Split arms block stats in Heretic, move them up in this case.
 		if( (gameinfo.gametype & GAME_Heretic) && splitHUD.getint() && splitArms.getint() && state == HUD_Fullscreen)
 			bHeightR += sfnt.armsOffset;
-		// Reposition based on Stats font setting
-		if(cozypos && !splitHUD.getint()) {
-			switch(statsFont.GetInt())
-			{
-				// Default Font
-				case 0:
-					sPush = sPushFontDefault;
-					bHeightR = bHeightFontDefault;
-					break;
-				// Console Font
-				case 1:
-					sPush = sPushFontConsole;
-					bHeightR = bHeightFontConsole;
-					break;
-				// Status Report Font
-				case 2:
-					sPush = sPushFontStatus;
-					bHeightR = bHeightFontStatus;
-					break;
-				// Memento Mori 2 Font
-				case 3:
-					sPush = sPushFontMementoMori;
-					bHeightR = bHeightFontMementoMori;
-					break;
-			}
-			if(itempos   == BOTTOMRIGHT) DrawStatLine(sfnt, itemComp ? compColor   : Font.CR_WHITE, (-sPush, -bHeightR-textSize*bottomRightTotal++) ,items,alphaFloat);
-			if(secretpos == BOTTOMRIGHT) DrawStatLine(sfnt, secretComp ? compColor : Font.CR_WHITE, (-sPush, -bHeightR-textSize*bottomRightTotal++) ,secrets,alphaFloat);
-			if(killpos   == BOTTOMRIGHT) DrawStatLine(sfnt, killComp   ? compColor : Font.CR_WHITE, (-sPush, -bHeightR-textSize*bottomRightTotal++) ,kills,alphaFloat);
-			if(timepos   == BOTTOMRIGHT) DrawStatLine(sfnt,                          Font.CR_WHITE, (-sPush, -bHeightR-textSize*bottomRightTotal++) ,time,alphaFloat);
-			if(powerpos  == BOTTOMRIGHT)
-				for(int i = 0; i < PowerupStrings.size(); i++)
-					DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW, (-sPush,-bHeightR-textSize*bottomRightTotal++), PowerupStrings[i],alphaFloat);
-		} else {
-			if(itempos   == BOTTOMRIGHT) DrawStatLine(sfnt, itemComp ? compColor   : Font.CR_WHITE, (-sPush-fnt.StringWidth(items),  -bHeightR-textSize*bottomRightTotal++),items,alphaFloat);
-			if(secretpos == BOTTOMRIGHT) DrawStatLine(sfnt, secretComp ? compColor : Font.CR_WHITE, (-sPush-fnt.StringWidth(secrets),-bHeightR-textSize*bottomRightTotal++),secrets,alphaFloat);
-			if(killpos   == BOTTOMRIGHT) DrawStatLine(sfnt, killComp   ? compColor : Font.CR_WHITE, (-sPush-fnt.StringWidth(kills),  -bHeightR-textSize*bottomRightTotal++)  ,kills,alphaFloat);
-			if(timepos   == BOTTOMRIGHT) DrawStatLine(sfnt,                          Font.CR_WHITE, (-sPush-fnt.StringWidth(time),   -bHeightR-textSize*bottomRightTotal++)   ,time,alphaFloat);
-			if(powerpos  == BOTTOMRIGHT)
-				for(int i = 0; i < PowerupStrings.size(); i++)
-					DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW, (-sPush-fnt.StringWidth(PowerupStrings[i]),-bHeightR-textSize*bottomRightTotal++), PowerupStrings[i],alphaFloat);
-		}
+		if(itempos   == BOTTOMRIGHT) DrawStatLine(sfnt, itemComp   ? compColor : Font.CR_WHITE, (-sPush-fnt.StringWidth(items),  -bHeightR-textSize*bottomRightTotal++)  ,items,alphaFloat);
+		if(secretpos == BOTTOMRIGHT) DrawStatLine(sfnt, secretComp ? compColor : Font.CR_WHITE, (-sPush-fnt.StringWidth(secrets),-bHeightR-textSize*bottomRightTotal++),secrets,alphaFloat);
+		if(killpos   == BOTTOMRIGHT) DrawStatLine(sfnt, killComp   ? compColor : Font.CR_WHITE, (-sPush-fnt.StringWidth(kills),  -bHeightR-textSize*bottomRightTotal++)  ,kills,alphaFloat);
+		if(timepos   == BOTTOMRIGHT) DrawStatLine(sfnt,                          Font.CR_WHITE, (-sPush-fnt.StringWidth(time),   -bHeightR-textSize*bottomRightTotal++)   ,time,alphaFloat);
+		if(powerpos  == BOTTOMRIGHT)
+			for(int i = 0; i < PowerupStrings.size(); i++)	
+				DrawStatLine(sfnt, (PowerupStrings[i] == morphString) ? Font.CR_ORANGE : Font.CR_YELLOW,
+				(-sPush-fnt.StringWidth(PowerupStrings[i]),-bHeightR-textSize*bottomRightTotal++), PowerupStrings[i],alphaFloat);
 	}
 
 	// =====================================================
@@ -561,7 +475,7 @@ mixin Class Stats
 
 		int scaleval;
 		// if (con_scale > 0) scaleval = !LZDoom ? (con_scale+1) / 2 : con_scale;
-		// else
+		// else 
 		if (uiscale == 0)
 		{
 			// Default should try to scale to 640x400
@@ -577,14 +491,14 @@ mixin Class Stats
 		int max = MAX(vmax, hmax);
 		return NewConsoleFont.GetHeight()*MAX(1, MIN(scaleval, max));
 	}
-
+	
 	// ==========================================================
 	// Helper Function to make string a specific length in a font
 	// ==========================================================
 	String makeLength(string input, font fnt, int length, string extender = ":")
 	{
 		if(fnt.StringWidth(input) > length) return input;
-
+		
 		int spacelength = (length - fnt.StringWidth(input))/fnt.StringWidth(" ");
 		string replacer = string.format(string.format("%%s%%%ds",spacelength), extender, "");
 		input.replace(extender,replacer);


### PR DESCRIPTION
Hey there! Awesome work on this very customizable mod.

I am an ultrawide user, so I prefer the centered Status Bar, however there was no option to have the stats adjacent to it, and I found it cumbersome to have them on the extreme edge of the viewport. I've never tinkered with zScript before, but the project code is clean, and well commented, so I gave it a shot, surprisingly made good headway, and put it through QA paces. Everything works quite well, using any supplied font. I have some switch cases in order to handle the fonts, due to their different metrics/sizing, as I was careful to ensure there was no overlapping/justification issues/etc..

The code in this PR will tell all, and you will notice some hardcoded values, however I believe they would be consistent across all viewports, since the very bottom edge is used for vertical placement, and the horizontal placement is based on the center-point of the Status Bar, with a (+/-) offset. Since the (non-split) Status Bar should be a consistent size, changing resolution/etc., doesn't seem to break anything.

Here's a quick preview of (most, if not all?) permutations/combinations of the settings:

https://user-images.githubusercontent.com/262645/208263441-6523a3d7-7cdc-4ef9-9457-3f2ea00fb571.mp4

Please inspect the code, test it out, and if everything looks good, I would be gracious if it  was merged in.

P.S. - Sorry for the large diff, but my editor removed whitespace, and changed line endings. The bulk of significant changes start at `L412` in `zscript/stats/stats.zs`, where the rest are mainly string and menu option updates. 

Thanks in advance!
